### PR TITLE
Fix failing tests: update plugin name from fastify-mcp to fastify-mcp-server

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -30,7 +30,7 @@ describe('MCP Fastify Plugin', () => {
     await app.register(mcpPlugin)
     await app.ready()
 
-    t.assert.ok(app.hasPlugin('fastify-mcp'))
+    t.assert.ok(app.hasPlugin('fastify-mcp-server'))
   })
 
   test('should register plugin with custom options', async (t: TestContext) => {
@@ -44,7 +44,7 @@ describe('MCP Fastify Plugin', () => {
     })
     await app.ready()
 
-    t.assert.ok(app.hasPlugin('fastify-mcp'))
+    t.assert.ok(app.hasPlugin('fastify-mcp-server'))
   })
 
   describe('MCP Protocol Handlers', () => {


### PR DESCRIPTION
## Summary
- Update test assertions to check for correct plugin name 'fastify-mcp-server'
- Fixes test failures after plugin rename in previous commits
- All 95 tests now pass with 0 failures

## Test plan
- [x] All existing tests pass (95/95)
- [x] Verified plugin name assertions are correct
- [x] No breaking changes to functionality

🤖 Generated with [Claude Code](https://claude.ai/code)