### PR TITLE
Rename project to @platformatic/mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Fastify plugin that implements the Model Context Protocol (MCP) server using J
 ## Installation
 
 ```bash
-npm install fastify-mcp-server
+npm install @platformatic/mcp
 ```
 
 ### TypeBox Support (Optional)
@@ -31,7 +31,7 @@ npm install @sinclair/typebox
 
 ```typescript
 import Fastify from 'fastify'
-import mcpPlugin from 'fastify-mcp-server'
+import mcpPlugin from '@platformatic/mcp'
 
 const app = Fastify({ logger: true })
 
@@ -135,7 +135,7 @@ The plugin supports TypeBox schemas for type-safe validation with automatic Type
 ```typescript
 import { Type } from '@sinclair/typebox'
 import Fastify from 'fastify'
-import mcpPlugin from 'fastify-mcp-server'
+import mcpPlugin from '@platformatic/mcp'
 
 const app = Fastify({ logger: true })
 
@@ -363,7 +363,7 @@ This transforms the plugin from a single-instance application into a distributed
 
 ```typescript
 import Fastify from 'fastify'
-import mcpPlugin from 'fastify-mcp-server'
+import mcpPlugin from '@platformatic/mcp'
 
 const app = Fastify({ logger: true })
 
@@ -478,7 +478,7 @@ The plugin provides methods to send notifications and messages to connected SSE 
 
 ```typescript
 import Fastify from 'fastify'
-import mcpPlugin from 'fastify-mcp-server'
+import mcpPlugin from '@platformatic/mcp'
 
 const app = Fastify({ logger: true })
 
@@ -579,8 +579,8 @@ The plugin includes a built-in stdio transport utility for MCP communication ove
 
 ```typescript
 import fastify from 'fastify'
-import mcpPlugin from 'fastify-mcp-server'
-import { runStdioServer } from 'fastify-mcp-server/stdio'
+import mcpPlugin from '@platformatic/mcp'
+import { runStdioServer } from '@platformatic/mcp/stdio'
 
 const app = fastify({
   logger: false // Disable HTTP logging to avoid interference with stdio
@@ -710,7 +710,7 @@ npm install @fastify/bearer-auth
 
 ```typescript
 import Fastify from 'fastify'
-import mcpPlugin from 'fastify-mcp-server'
+import mcpPlugin from '@platformatic/mcp'
 
 const app = Fastify({ logger: true })
 

--- a/examples/stdio-server.ts
+++ b/examples/stdio-server.ts
@@ -10,7 +10,7 @@ const app = fastify({
 // Register the MCP plugin
 await app.register(mcpPlugin, {
   serverInfo: {
-    name: 'fastify-mcp-stdio-example',
+    name: '@platformatic/mcp-stdio-example',
     version: '1.0.0'
   },
   capabilities: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fastify-mcp-server",
+  "name": "@platformatic/mcp",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fastify-mcp-server",
+      "name": "@platformatic/mcp",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fastify-mcp-server",
+  "name": "@platformatic/mcp",
   "version": "0.0.1",
   "description": "Fastify adapter for MCP",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import routes from './routes.ts'
 
 export default fp(async function (app: FastifyInstance, opts: MCPPluginOptions) {
   const serverInfo: Implementation = opts.serverInfo ?? {
-    name: 'fastify-mcp-server',
+    name: '@platformatic/mcp',
     version: '1.0.0'
   }
 
@@ -87,5 +87,5 @@ export default fp(async function (app: FastifyInstance, opts: MCPPluginOptions) 
     await messageBroker.close()
   })
 }, {
-  name: 'fastify-mcp-server'
+  name: '@platformatic/mcp'
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -30,7 +30,7 @@ describe('MCP Fastify Plugin', () => {
     await app.register(mcpPlugin)
     await app.ready()
 
-    t.assert.ok(app.hasPlugin('fastify-mcp-server'))
+    t.assert.ok(app.hasPlugin('@platformatic/mcp'))
   })
 
   test('should register plugin with custom options', async (t: TestContext) => {
@@ -44,7 +44,7 @@ describe('MCP Fastify Plugin', () => {
     })
     await app.ready()
 
-    t.assert.ok(app.hasPlugin('fastify-mcp-server'))
+    t.assert.ok(app.hasPlugin('@platformatic/mcp'))
   })
 
   describe('MCP Protocol Handlers', () => {

--- a/test/stdio-simple.test.ts
+++ b/test/stdio-simple.test.ts
@@ -86,7 +86,7 @@ test('stdio transport - full integration test', async () => {
     assert.strictEqual(initResponse.id, 1)
     assert(initResponse.result, 'Should have result')
     assert(initResponse.result.serverInfo, 'Should have serverInfo')
-    assert.strictEqual(initResponse.result.serverInfo.name, 'fastify-mcp-stdio-example')
+    assert.strictEqual(initResponse.result.serverInfo.name, '@platformatic/mcp-stdio-example')
 
     // Test 2: Ping request
     const pingRequest = {


### PR DESCRIPTION
## Summary
This PR renames the project from `fastify-mcp-server` to `@platformatic/mcp` to align with the Platformatic naming convention and scoped package structure.

## Changes Made
- Updated `package.json` and `package-lock.json` with new scoped package name
- Updated all import statements and install commands in `README.md`
- Updated plugin name and default server name in source code
- Updated test expectations to match new names
- Updated example server name to reflect new package name
- All documentation consistently uses the new package name

## Test Results
- ✅ All 95 tests pass
- ✅ Linting passes with no errors  
- ✅ Type checking passes with no errors
- ✅ All functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)