### PR TITLE
Skip auth for the start of the OAuth flow

### DIFF
--- a/src/auth/prehandler.ts
+++ b/src/auth/prehandler.ts
@@ -17,6 +17,11 @@ export function createAuthPreHandler (
       return
     }
 
+    // Skip authorization for the start of the OAuth authorization flow.
+    if (request.url.startsWith('/oauth/authorize')) {
+      return
+    }
+
     // Extract Bearer token from Authorization header
     const authHeader = request.headers.authorization
     if (!authHeader) {

--- a/src/auth/session-auth-prehandler.ts
+++ b/src/auth/session-auth-prehandler.ts
@@ -31,6 +31,11 @@ export function createSessionAuthPreHandler (
       return
     }
 
+    // Skip authorization for the start of the OAuth authorization flow.
+    if (request.url.startsWith('/oauth/authorize')) {
+      return
+    }
+
     // Extract Bearer token from Authorization header
     const authHeader = request.headers.authorization
     if (!authHeader) {

--- a/test/auth-prehandler.test.ts
+++ b/test/auth-prehandler.test.ts
@@ -70,6 +70,27 @@ describe('Authorization PreHandler', () => {
     validator.close()
   })
 
+  test('should skip authorization for the start of the OAuth authorization flow', async (t: TestContext) => {
+    const config = createTestAuthConfig()
+    const validator = new TokenValidator(config, app)
+    const preHandler = createAuthPreHandler(config, validator)
+
+    app.addHook('preHandler', preHandler)
+    app.get('/oauth/authorize', async () => ({ success: true }))
+
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/oauth/authorize'
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.deepStrictEqual(response.json(), { success: true })
+
+    validator.close()
+  })
+
   test('should return 401 when no Authorization header', async (t: TestContext) => {
     const config = createTestAuthConfig()
     const validator = new TokenValidator(config, app)


### PR DESCRIPTION
Can't start the OAuth flow if the first route (`GET /oauth/authorize`) requires auth to begin with.