### PR TITLE
feat(resources): Add resources/subscribe and resources/unsubscribe support

### DIFF
--- a/src/decorators/meta.ts
+++ b/src/decorators/meta.ts
@@ -3,7 +3,10 @@ import fp from 'fastify-plugin'
 import type {
   MCPTool,
   MCPResource,
-  MCPPrompt
+  MCPPrompt,
+  ResourceHandlers,
+  ResourceSubscribeHandler,
+  ResourceUnsubscribeHandler
 } from '../types.ts'
 import { schemaToArguments, validateToolSchema } from '../validation/index.ts'
 
@@ -11,10 +14,11 @@ interface MCPDecoratorsOptions {
   tools: Map<string, MCPTool>
   resources: Map<string, MCPResource>
   prompts: Map<string, MCPPrompt>
+  resourceHandlers: ResourceHandlers
 }
 
 const mcpDecoratorsPlugin: FastifyPluginAsync<MCPDecoratorsOptions> = async (app, options) => {
-  const { tools, resources, prompts } = options
+  const { tools, resources, prompts, resourceHandlers } = options
 
   // Enhanced tool decorator with TypeBox schema support
   app.decorate('mcpAddTool', (
@@ -92,6 +96,15 @@ const mcpDecoratorsPlugin: FastifyPluginAsync<MCPDecoratorsOptions> = async (app
       },
       handler
     })
+  })
+
+  // Resource subscription handler setters
+  app.decorate('mcpSetResourceSubscribeHandler', (handler: ResourceSubscribeHandler) => {
+    resourceHandlers.subscribeHandler = handler
+  })
+
+  app.decorate('mcpSetResourceUnsubscribeHandler', (handler: ResourceUnsubscribeHandler) => {
+    resourceHandlers.unsubscribeHandler = handler
   })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { MemorySessionStore } from './stores/memory-session-store.ts'
 import { MemoryMessageBroker } from './brokers/memory-message-broker.ts'
 import { RedisSessionStore } from './stores/redis-session-store.ts'
 import { RedisMessageBroker } from './brokers/redis-message-broker.ts'
-import type { MCPPluginOptions, MCPTool, MCPResource, MCPPrompt } from './types.ts'
+import type { MCPPluginOptions, MCPTool, MCPResource, MCPPrompt, ResourceHandlers } from './types.ts'
 import pubsubDecorators from './decorators/pubsub.ts'
 import metaDecorators from './decorators/meta.ts'
 import routes from './routes/mcp.ts'
@@ -50,6 +50,7 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
   const tools = new Map<string, MCPTool>()
   const resources = new Map<string, MCPResource>()
   const prompts = new Map<string, MCPPrompt>()
+  const resourceHandlers: ResourceHandlers = {}
 
   // Initialize stores and brokers based on configuration
   let sessionStore: SessionStore
@@ -98,7 +99,8 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
   app.register(metaDecorators, {
     tools,
     resources,
-    prompts
+    prompts,
+    resourceHandlers
   })
   app.register(pubsubDecorators, {
     enableSSE,
@@ -116,6 +118,7 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
     tools,
     resources,
     prompts,
+    resourceHandlers,
     sessionStore,
     messageBroker,
     localStreams
@@ -188,7 +191,10 @@ export type {
   UnsafeToolHandler,
   UnsafeResourceHandler,
   UnsafePromptHandler,
-  SSESession
+  SSESession,
+  ResourceHandlers,
+  ResourceSubscribeHandler,
+  ResourceUnsubscribeHandler
 } from './types.ts'
 
 // Export authorization types

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -3,7 +3,7 @@ import type { FastifyRequest, FastifyReply, FastifyPluginAsync } from 'fastify'
 import fp from 'fastify-plugin'
 import type { JSONRPCMessage } from '../schema.ts'
 import { JSONRPC_VERSION, INTERNAL_ERROR } from '../schema.ts'
-import type { MCPPluginOptions, MCPTool, MCPResource, MCPPrompt } from '../types.ts'
+import type { MCPPluginOptions, MCPTool, MCPResource, MCPPrompt, ResourceHandlers } from '../types.ts'
 import type { SessionStore, SessionMetadata } from '../stores/session-store.ts'
 import type { MessageBroker } from '../brokers/message-broker.ts'
 import type { AuthorizationContext } from '../types/auth-types.ts'
@@ -17,13 +17,14 @@ interface MCPPubSubRoutesOptions {
   tools: Map<string, MCPTool>
   resources: Map<string, MCPResource>
   prompts: Map<string, MCPPrompt>
+  resourceHandlers: ResourceHandlers
   sessionStore: SessionStore
   messageBroker: MessageBroker
   localStreams: Map<string, Set<any>>
 }
 
 const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async (app, options) => {
-  const { enableSSE, opts, capabilities, serverInfo, tools, resources, prompts, sessionStore, messageBroker, localStreams } = options
+  const { enableSSE, opts, capabilities, serverInfo, tools, resources, prompts, resourceHandlers, sessionStore, messageBroker, localStreams } = options
 
   async function createSSESession (): Promise<SessionMetadata> {
     const sessionId = randomUUID()
@@ -185,6 +186,7 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
         tools,
         resources,
         prompts,
+        resourceHandlers,
         request,
         reply,
         authContext

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,23 @@ export interface HandlerContext {
   authContext?: AuthorizationContext
 }
 
+// Resource subscription handler types
+export type ResourceSubscribeHandler = (
+  params: { uri: string },
+  context: HandlerContext
+) => Promise<Record<string, unknown>> | Record<string, unknown>
+
+export type ResourceUnsubscribeHandler = (
+  params: { uri: string },
+  context: HandlerContext
+) => Promise<Record<string, unknown>> | Record<string, unknown>
+
+// Resource handlers container
+export interface ResourceHandlers {
+  subscribeHandler?: ResourceSubscribeHandler
+  unsubscribeHandler?: ResourceUnsubscribeHandler
+}
+
 // Generic handler types with TypeBox schema support
 export type ToolHandler<TSchema extends TObject = TObject> = (
   params: Static<TSchema>,
@@ -107,6 +124,10 @@ declare module 'fastify' {
       requestedSchema: ElicitRequest['params']['requestedSchema'],
       requestId?: RequestId
     ) => Promise<boolean>
+
+    // Resource subscription handler setters
+    mcpSetResourceSubscribeHandler: (handler: ResourceSubscribeHandler) => void
+    mcpSetResourceUnsubscribeHandler: (handler: ResourceUnsubscribeHandler) => void
   }
 }
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -160,7 +160,11 @@ describe('MCP Integration Tests', () => {
         }
       }, CallToolResultSchema)
 
-      t.assert.strictEqual(divResult.content[0].text, 'Result: 5')
+      const divContent = divResult.content[0]
+      t.assert.strictEqual(divContent.type, 'text')
+      if (divContent.type === 'text') {
+        t.assert.strictEqual(divContent.text, 'Result: 5')
+      }
 
       // Test tool execution with error
       const errorResult = await client.request({
@@ -172,7 +176,11 @@ describe('MCP Integration Tests', () => {
       }, CallToolResultSchema)
 
       t.assert.strictEqual(errorResult.isError, true)
-      t.assert.ok((errorResult.content[0].text as string).includes('Invalid operation'))
+      const errorContent = errorResult.content[0]
+      t.assert.strictEqual(errorContent.type, 'text')
+      if (errorContent.type === 'text') {
+        t.assert.ok(errorContent.text.includes('Invalid operation'))
+      }
 
       // Test resources listing
       const resourcesResult = await client.request({
@@ -189,9 +197,11 @@ describe('MCP Integration Tests', () => {
         params: { uri: 'config://settings.json' }
       }, ReadResourceResultSchema)
 
-      t.assert.strictEqual(configResult.contents[0].uri, 'config://settings.json')
-      t.assert.strictEqual(configResult.contents[0].mimeType, 'application/json')
-      const config = JSON.parse(configResult.contents[0].text as string)
+      const configContent = configResult.contents[0]
+      t.assert.strictEqual(configContent.uri, 'config://settings.json')
+      t.assert.strictEqual(configContent.mimeType, 'application/json')
+      t.assert.ok('text' in configContent, 'Expected text content')
+      const config = JSON.parse((configContent as { text: string }).text)
       t.assert.strictEqual(config.mode, 'test')
       t.assert.strictEqual(config.debug, true)
 
@@ -215,7 +225,11 @@ describe('MCP Integration Tests', () => {
 
       t.assert.strictEqual(promptResult.messages.length, 1)
       t.assert.strictEqual(promptResult.messages[0].role, 'user')
-      t.assert.ok((promptResult.messages[0].content.text as string).includes('typescript'))
+      const promptContent = promptResult.messages[0].content
+      t.assert.strictEqual(promptContent.type, 'text')
+      if (promptContent.type === 'text') {
+        t.assert.ok(promptContent.text.includes('typescript'))
+      }
     } catch (error) {
       t.assert.fail(`MCP SDK integration test failed: ${error}`)
     }
@@ -341,6 +355,10 @@ describe('MCP Integration Tests', () => {
     }, CallToolResultSchema)
 
     t.assert.strictEqual(callResult.isError, true)
-    t.assert.ok((callResult.content[0].text as string).includes('no handler implementation'))
+    const noHandlerContent = callResult.content[0]
+    t.assert.strictEqual(noHandlerContent.type, 'text')
+    if (noHandlerContent.type === 'text') {
+      t.assert.ok(noHandlerContent.text.includes('no handler implementation'))
+    }
   })
 })


### PR DESCRIPTION
## Summary

This PR adds MCP spec-compliant `resources/subscribe` and `resources/unsubscribe` methods, plus query parameter URI matching for resources with `uriSchema`.

Closes #96

## Changes

### 1. Custom Subscription Handlers

Applications can now implement their own subscription storage:

```typescript
// Application manages its own subscription store
const subscriptions = new Map<string, Set<string>>();

app.mcpSetResourceSubscribeHandler(async (params, context) => {
  const subs = subscriptions.get(params.uri) || new Set();
  subs.add(context.sessionId!);
  subscriptions.set(params.uri, subs);
  return {};
});

app.mcpSetResourceUnsubscribeHandler(async (params, context) => {
  const subs = subscriptions.get(params.uri);
  if (subs) subs.delete(context.sessionId!);
  return {};
});

// Notify on resource change via existing mcpSendToSession
const subs = subscriptions.get(changedUri);
for (const sessionId of subs || []) {
  await app.mcpSendToSession(sessionId, {
    jsonrpc: '2.0',
    method: 'notifications/resources/updated',
    params: { uri: changedUri }
  });
}
```

### 2. Query Parameter URI Matching

Resources with `uriSchema` can now be read with query parameters:

```typescript
app.mcpAddResource({
  uri: 'aip://findings',
  name: 'Findings',
  uriSchema: Type.Object({ id: Type.String() })
}, async (uri, context) => {
  const url = new URL(uri, 'http://x');
  const id = url.searchParams.get('id');
  // ...
});

// Client can now read: 'aip://findings?id=abc123'
// Falls back to 'aip://findings' base URI because it has uriSchema
```

## Files Changed

- `src/types.ts` - Add subscription handler types and Fastify declaration
- `src/decorators/meta.ts` - Add setter decorators
- `src/handlers.ts` - Add subscription handlers and query param fallback
- `src/index.ts` - Create and pass resourceHandlers
- `src/routes/mcp.ts` - Include resourceHandlers in dependencies
- `test/integration.test.ts` - Fix type guards (cherry-picked)

## Design Decisions

1. **Custom handlers, not built-in tracking** - Applications manage their own storage
2. **METHOD_NOT_FOUND when not configured** - Clear signal that feature isn't enabled
3. **uriSchema as query param indicator** - Only falls back if resource expects params

## Backwards Compatibility

- Existing `mcpAddResource` registrations unchanged
- Default `resources/read` behavior unchanged for exact matches
- New decorators are optional

## Test Plan

- [x] TypeScript compiles (`npm run typecheck`)
- [ ] Existing tests pass (`npm run test`)
- [ ] Manual testing with MCP client

---

🤖 Generated with [Claude Code](https://claude.ai/code)