### PR TITLE
fix: use full configured jwksUri and introspectionEndpoint paths

### DIFF
--- a/src/auth/token-validator.ts
+++ b/src/auth/token-validator.ts
@@ -25,7 +25,8 @@ export class TokenValidator {
 
       this.getJwks = buildGetJwks({
         max: 50,
-        ttl: 600000 // 10 minutes
+        ttl: 600000, // 10 minutes
+        jwksPath: jwksUrl.pathname
       })
 
       this.jwtVerifier = createVerifier({

--- a/src/routes/well-known.ts
+++ b/src/routes/well-known.ts
@@ -166,7 +166,7 @@ const wellKnownRoutesPlugin = fp(async function (app: FastifyInstance, opts: Wel
         'mcp:prompts',
         'mcp:tools'
       ],
-      token_introspection_endpoint: `${primaryAuthServer}/oauth/introspect`,
+      token_introspection_endpoint: authConfig.tokenValidation.introspectionEndpoint ?? `${primaryAuthServer}/oauth/introspect`,
       jwks_uri: authConfig.tokenValidation.jwksUri || null,
       mcp_resource_uri: authConfig.resourceUri,
       mcp_authorization_servers: authConfig.authorizationServers

--- a/test/auth-test-utils.ts
+++ b/test/auth-test-utils.ts
@@ -164,13 +164,10 @@ export function setupMockAgent (responses: Record<string, any>) {
       method: 'GET'
     }).reply(statusCode, JSON.stringify(responseBody), headers).persist()
 
-    // Also intercept POST for introspection endpoints
-    if (url.includes('/introspect')) {
-      mockPool.intercept({
-        path: urlObj.pathname + urlObj.search,
-        method: 'POST'
-      }).reply(statusCode, JSON.stringify(responseBody), headers).persist()
-    }
+    mockPool.intercept({
+      path: urlObj.pathname + urlObj.search,
+      method: 'POST'
+    }).reply(statusCode, JSON.stringify(responseBody), headers).persist()
   }
 
   return () => {

--- a/test/token-validator.test.ts
+++ b/test/token-validator.test.ts
@@ -352,6 +352,190 @@ describe('TokenValidator', () => {
     })
   })
 
+  describe('Custom Introspection Endpoint Path', () => {
+    // Some providers use non-standard introspection paths (e.g. /oauth2/introspection rather than /introspect)
+    test('should validate token via custom /oauth2/introspection path', async (t: TestContext) => {
+      const config = createTestAuthConfig({
+        tokenValidation: {
+          introspectionEndpoint: 'https://sample-instance-01.authkit.app/oauth2/introspection',
+          validateAudience: true
+        }
+      })
+
+      restoreMock = setupMockAgent({
+        'https://sample-instance-01.authkit.app/oauth2/introspection': createIntrospectionResponse(true)
+      })
+
+      const validator = new TokenValidator(config, app)
+      const result = await validator.validateToken('opaque-token-123')
+
+      t.assert.strictEqual(result.valid, true)
+      t.assert.ok(result.payload)
+      t.assert.strictEqual(result.payload.active, true)
+
+      validator.close()
+    })
+
+    test('should reject inactive token via custom /oauth2/introspection path', async (t: TestContext) => {
+      const config = createTestAuthConfig({
+        tokenValidation: {
+          introspectionEndpoint: 'https://sample-instance-01.authkit.app/oauth2/introspection',
+          validateAudience: true
+        }
+      })
+
+      restoreMock = setupMockAgent({
+        'https://sample-instance-01.authkit.app/oauth2/introspection': createIntrospectionResponse(false)
+      })
+
+      const validator = new TokenValidator(config, app)
+      const result = await validator.validateToken('opaque-token-123')
+
+      t.assert.strictEqual(result.valid, false)
+      t.assert.strictEqual(result.error, 'Token is not active')
+
+      validator.close()
+    })
+
+    test('should validate token via deeply nested custom introspection path', async (t: TestContext) => {
+      const config = createTestAuthConfig({
+        tokenValidation: {
+          introspectionEndpoint: 'https://auth.example.com/v1/tokens/validate',
+          validateAudience: true
+        }
+      })
+
+      restoreMock = setupMockAgent({
+        'https://auth.example.com/v1/tokens/validate': createIntrospectionResponse(true)
+      })
+
+      const validator = new TokenValidator(config, app)
+      const result = await validator.validateToken('opaque-token-123')
+
+      t.assert.strictEqual(result.valid, true)
+      t.assert.ok(result.payload)
+
+      validator.close()
+    })
+
+    test('should handle error from custom introspection path', async (t: TestContext) => {
+      const config = createTestAuthConfig({
+        tokenValidation: {
+          introspectionEndpoint: 'https://sample-instance-01.authkit.app/oauth2/introspection',
+          validateAudience: true
+        }
+      })
+
+      restoreMock = setupMockAgent({
+        'https://sample-instance-01.authkit.app/oauth2/introspection': {
+          status: 401,
+          body: { error: 'unauthorized' }
+        }
+      })
+
+      const validator = new TokenValidator(config, app)
+      const result = await validator.validateToken('opaque-token-123')
+
+      t.assert.strictEqual(result.valid, false)
+      t.assert.ok(result.error?.includes('Introspection failed with status 401'))
+
+      validator.close()
+    })
+  })
+
+  describe('Custom JWKS URI Path', () => {
+    // Some providers use non-standard JWKS paths (e.g. /oauth2/jwks rather than /.well-known/jwks.json)
+    test('should validate JWT using custom JSWKS path', async (t: TestContext) => {
+      const config = createTestAuthConfig({
+        tokenValidation: {
+          jwksUri: 'https://sample-instance-01.authkit.app/oauth2/jwks',
+          validateAudience: true
+        }
+      })
+      restoreMock = setupMockAgent({
+        'https://sample-instance-01.authkit.app/oauth2/jwks': generateMockJWKSResponse()
+      })
+
+      const validator = new TokenValidator(config, app)
+      const token = createTestJWT({ iss: 'https://sample-instance-01.authkit.app', aud: 'https://mcp.example.com' })
+
+      const result = await validator.validateToken(token)
+
+      t.assert.strictEqual(result.valid, true)
+      t.assert.ok(result.payload)
+      t.assert.strictEqual(result.payload.sub, 'test-user')
+
+      validator.close()
+    })
+
+    test('should validate JWT using deeply nested custom JWKS path', async (t: TestContext) => {
+      const config = createTestAuthConfig({
+        tokenValidation: {
+          jwksUri: 'https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/certs',
+          validateAudience: true
+        }
+      })
+      restoreMock = setupMockAgent({
+        'https://auth.example.com/auth/realms/myrealm/protocol/openid-connect/certs': generateMockJWKSResponse()
+      })
+
+      const validator = new TokenValidator(config, app)
+      const token = createTestJWT()
+
+      const result = await validator.validateToken(token)
+
+      t.assert.strictEqual(result.valid, true)
+      t.assert.ok(result.payload)
+
+      validator.close()
+    })
+
+    test('should fail JWT validation when custom JWKS path returns 404', async (t: TestContext) => {
+      const config = createTestAuthConfig({
+        tokenValidation: {
+          jwksUri: 'https://sample-instance-01.authkit.app/oauth2/jwks',
+          validateAudience: false
+        }
+      })
+      restoreMock = setupMockAgent({
+        'https://sample-instance-01.authkit.app/oauth2/jwks': { status: 404, body: { error: 'not found' } }
+      })
+
+      const validator = new TokenValidator(config, app)
+      const token = createTestJWT({ iss: 'https://sample-instance-01.authkit.app', aud: 'https://mcp.example.com' })
+
+      const result = await validator.validateToken(token)
+
+      t.assert.strictEqual(result.valid, false)
+      t.assert.ok(result.error)
+
+      validator.close()
+    })
+
+    test('should not fetch /.well-known/jwks.json when custom path configured', async (t: TestContext) => {
+      const config = createTestAuthConfig({
+        tokenValidation: {
+          jwksUri: 'https://sample-instance-01.authkit.app/oauth2/jwks',
+          validateAudience: false
+        }
+      })
+      // Only mock the custom path — if the validator incorrectly fetches the default
+      // path, disableNetConnect will cause it to fail
+      restoreMock = setupMockAgent({
+        'https://sample-instance-01.authkit.app/oauth2/jwks': generateMockJWKSResponse()
+      })
+
+      const validator = new TokenValidator(config, app)
+      const token = createTestJWT({ iss: 'https://sample-instance-01.authkit.app', aud: 'https://mcp.example.com' })
+
+      const result = await validator.validateToken(token)
+
+      t.assert.strictEqual(result.valid, true)
+
+      validator.close()
+    })
+  })
+
   describe('Fallback Logic', () => {
     test('should fallback to introspection when JWT validation fails', async (t: TestContext) => {
       const config = createTestAuthConfig({

--- a/test/well-known-routes.test.ts
+++ b/test/well-known-routes.test.ts
@@ -381,6 +381,55 @@ describe('Well-known Routes', () => {
       ])
     })
 
+    test('should use configured introspectionEndpoint in token_introspection_endpoint field', async (t: TestContext) => {
+      // Providers like WorkOS AuthKit use non-standard paths (e.g. /oauth2/introspection)
+      const authConfig = createTestAuthConfig({
+        resourceUri: 'https://mcp.test.com',
+        authorizationServers: ['https://sample-instance-01.authkit.app'],
+        tokenValidation: {
+          introspectionEndpoint: 'https://sample-instance-01.authkit.app/oauth2/introspection',
+          validateAudience: true
+        }
+      })
+
+      await app.register(wellKnownRoutes, { authConfig })
+      await app.ready()
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/openid-configuration/mcp'
+      })
+
+      t.assert.strictEqual(response.statusCode, 200)
+      const body = response.json()
+      t.assert.strictEqual(
+        body.token_introspection_endpoint,
+        'https://sample-instance-01.authkit.app/oauth2/introspection'
+      )
+    })
+
+    test('should fall back to default introspect path when introspectionEndpoint not configured', async (t: TestContext) => {
+      const authConfig = createTestAuthConfig({
+        resourceUri: 'https://mcp.test.com',
+        authorizationServers: ['https://auth1.example.com'],
+        tokenValidation: {
+          validateAudience: true
+        }
+      })
+
+      await app.register(wellKnownRoutes, { authConfig })
+      await app.ready()
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/.well-known/openid-configuration/mcp'
+      })
+
+      t.assert.strictEqual(response.statusCode, 200)
+      const body = response.json()
+      t.assert.strictEqual(body.token_introspection_endpoint, 'https://auth1.example.com/oauth/introspect')
+    })
+
     test('should return OpenID Connect configuration without JWKS URI when not configured', async (t: TestContext) => {
       const authConfig = createTestAuthConfig({
         resourceUri: 'https://mcp.simple.com',


### PR DESCRIPTION
Previously, buildGetJwks ignored the path component of jwksUri (always fetching /.well-known/jwks.json), and the /.well-known/openid-configuration/mcp metadata endpoint hard-coded /oauth/introspect as the token_introspection_endpoint regardless of what was set in tokenValidation.introspectionEndpoint.

I discovered this while getting `@platformatic/mcp` to work with [WorkOS MCP OAuth support](https://workos.com/docs/authkit/mcp). WorkOS uses some "non-standard" URLs, particularly the JWKS URI. While I was able to specify the custom URL it was not actually being used.

I also noticed a few other bits of hard-coding: WorkOS also deviates on the introspection URL pathname, nothing actually needed to be _updated_ beyond the OIDC discovery endpoint however I had Claude help write some covering tests anyways. 