### PR TITLE
feat: implement MCP 2025-11-25 specification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Uses a base TypeScript configuration (`tsconfig.base.json`) extended by the main
 ## Testing
 
 The project includes comprehensive test coverage:
-- **178 tests total** covering all functionality including OAuth 2.1 authorization
+- **369 tests total** covering all functionality including OAuth 2.1 authorization and tasks
 - **Memory backend tests**: Session management, message broadcasting, SSE handling
 - **Redis backend tests**: Session persistence, cross-instance messaging, failover
 - **Integration tests**: Full plugin lifecycle, multi-instance deployment

--- a/README.md
+++ b/README.md
@@ -209,13 +209,26 @@ A client opts in per call by adding a `task` field:
 Supported operations: `tasks/get`, `tasks/result` (blocks until the task is terminal),
 `tasks/list` and `tasks/cancel`, plus optional `notifications/tasks/status` pushes over SSE.
 
+Retention defaults to 60 seconds when the client does not request a `ttl`. Tasks are meant
+for long-running work, so if your tools can outlive that, raise the bounds — otherwise a task
+can expire before it finishes and its `tasks/result` returns "not found":
+
+```typescript
+await app.register(mcpPlugin, {
+  enableTasks: true,
+  taskDefaultTtlMs: 15 * 60_000, // retention when the client requests no ttl
+  taskMaxTtlMs: 60 * 60_000      // ceiling on a client-requested ttl
+})
+```
+
 Tasks are stored in memory by default and in Redis when a `redis` option is given, so any
 instance can serve a poll for a task created on another.
 
 **Security**: when authorization is enabled, tasks are bound to the token subject and a
 requestor can only reach its own. Without authorization no requestor can be identified, so
-tasks are reachable by anyone holding the (random UUID) task id and `tasks/list` is not
-advertised.
+tasks are reachable by anyone holding the (random UUID) task id, and `tasks/list` is both
+unadvertised **and refused** — otherwise it would hand every anonymous task's id to any
+caller and defeat that model.
 
 ## Elicitation Support (MCP 2025-11-25)
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,29 @@ On the HTTP transport, requests after `initialize` must carry the agreed revisio
 `MCP-Protocol-Version` header. An unsupported value is answered with `400`; an absent header
 is treated as `2025-03-26`, which predates the header.
 
+**Responses are shaped to the revision the client negotiated.** A client on an older revision
+never sees a field or method that revision does not define:
+
+| | `< 2025-11-25` | `2025-11-25` |
+|---|---|---|
+| `tasks` capability | not advertised | advertised |
+| `tasks/*` methods | `-32601` method not found | available |
+| `task` field on `tools/call` | ignored | honoured |
+| `icons` on listings | stripped | present |
+| `execution.taskSupport` | stripped | present |
+| `$schema` on tool schemas | omitted | JSON Schema 2020-12 |
+| URL mode elicitation | refused | available |
+
+When SSE is enabled the negotiated revision is stored on the session and is **authoritative**:
+a request whose `MCP-Protocol-Version` header contradicts what the session agreed is rejected
+with `400`, so a client cannot opt into newer behaviour after negotiating an older revision.
+When the header is omitted the session's revision is used in preference to the `2025-03-26`
+default. `initialize` is exempt, so a client may re-negotiate on an existing session.
+
+> Without SSE there is no session to remember the negotiation, so each request is judged
+> solely by its header. A client that omits it falls back to `2025-03-26` and will not see
+> `2025-11-25` features. Compliant clients always send the header.
+
 ## Origin Validation
 
 Browser clients can be protected against DNS rebinding by allow-listing origins. A rejected

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ npm install @sinclair/typebox
 
 ## Features
 
-- **Complete MCP 2025-06-18 Support**: Implements the full Model Context Protocol specification with elicitation
-- **Elicitation Support**: Server-to-client information requests with schema validation
+- **Complete MCP 2025-11-25 Support**: Implements the current Model Context Protocol revision, negotiating down to `2025-06-18`, `2025-03-26` and `2024-11-05` for older clients
+- **Tasks (experimental)**: Task-augmented tool calls with polling, deferred result retrieval and cancellation
+- **Elicitation Support**: Server-to-client information requests in both form and URL mode, with schema validation
+- **Icons**: Optional icon metadata on tools, resources, resource templates and prompts
 - **TypeBox Validation**: Type-safe schema validation with automatic TypeScript inference
 - **Security Enhancements**: Input sanitization, rate limiting, and security assessment
 - **Multiple Transport Support**: HTTP/SSE and stdio transports for flexible communication
@@ -122,9 +124,99 @@ app.mcpAddPrompt({
 await app.listen({ port: 3000 })
 ```
 
-## Elicitation Support (MCP 2025-06-18)
+## Protocol Version Negotiation
+
+The server answers `initialize` with the client's requested revision when it is one it
+supports, and otherwise offers the newest one it has:
+
+```typescript
+import { LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from '@platformatic/mcp'
+
+LATEST_PROTOCOL_VERSION      // '2025-11-25'
+SUPPORTED_PROTOCOL_VERSIONS  // ['2025-11-25', '2025-06-18', '2025-03-26', '2024-11-05']
+```
+
+On the HTTP transport, requests after `initialize` must carry the agreed revision in the
+`MCP-Protocol-Version` header. An unsupported value is answered with `400`; an absent header
+is treated as `2025-03-26`, which predates the header.
+
+## Origin Validation
+
+Browser clients can be protected against DNS rebinding by allow-listing origins. A rejected
+origin is answered with `403`:
+
+```typescript
+await app.register(mcpPlugin, {
+  allowedOrigins: ['https://app.example.com'] // omit to disable, '*' or true to allow any
+})
+```
+
+Requests without an `Origin` header are always accepted — the header is set by browsers, so
+its absence means the request did not come from one.
+
+## Tasks (MCP 2025-11-25, experimental)
+
+Tasks let a tool call return immediately with a task handle while the work continues in the
+background. The client then polls `tasks/get` and collects the result with `tasks/result`.
+
+Enable the feature on the plugin, then opt individual tools in with `execution.taskSupport`:
+
+```typescript
+await app.register(mcpPlugin, { enableTasks: true })
+
+app.mcpAddTool({
+  name: 'generate-report',
+  description: 'Builds a large report',
+  inputSchema: Type.Object({ month: Type.String() }),
+  execution: { taskSupport: 'optional' } // 'forbidden' (default) | 'optional' | 'required'
+}, async (params) => {
+  return { content: [{ type: 'text', text: await buildReport(params.month) }] }
+})
+```
+
+A client opts in per call by adding a `task` field:
+
+```jsonc
+// -> tools/call
+{ "name": "generate-report", "arguments": { "month": "July" }, "task": { "ttl": 60000 } }
+// <- CreateTaskResult
+{ "task": { "taskId": "…", "status": "working", "ttl": 60000, "pollInterval": 1000 } }
+```
+
+Supported operations: `tasks/get`, `tasks/result` (blocks until the task is terminal),
+`tasks/list` and `tasks/cancel`, plus optional `notifications/tasks/status` pushes over SSE.
+
+Tasks are stored in memory by default and in Redis when a `redis` option is given, so any
+instance can serve a poll for a task created on another.
+
+**Security**: when authorization is enabled, tasks are bound to the token subject and a
+requestor can only reach its own. Without authorization no requestor can be identified, so
+tasks are reachable by anyone holding the (random UUID) task id and `tasks/list` is not
+advertised.
+
+## Elicitation Support (MCP 2025-11-25)
 
 The plugin supports the elicitation capability, allowing servers to request structured information from clients. This enables dynamic data collection with schema validation.
+
+Two modes are available. **Form mode** collects structured data through the client, and
+**URL mode** sends the user out of band for anything sensitive — credentials, payments,
+third-party OAuth — so it never passes through the MCP client:
+
+```typescript
+// URL mode: returns the elicitation id, or null if the request could not be sent
+const elicitationId = await app.mcpElicitUrl(
+  sessionId,
+  'Authorize access to your Example Co files',
+  'https://mcp.example.com/connect'
+)
+
+// Later, once the out-of-band interaction finishes
+await app.mcpNotifyElicitationComplete(sessionId, elicitationId)
+```
+
+Servers **MUST NOT** request passwords, API keys or payment details through form mode — use
+URL mode for those. URLs are rejected if they are malformed, use a scheme other than
+http(s), or embed credentials.
 
 ### Basic Elicitation
 
@@ -448,6 +540,9 @@ This plugin supports the MCP Streamable HTTP transport specification, enabling b
 ```typescript
 await app.register(mcpPlugin, {
   enableSSE: true, // Enable SSE support (default: false)
+  // Optionally close streams after a while so clients fall back to polling and
+  // resume with Last-Event-ID (SEP-1699). Omit to keep streams open indefinitely.
+  sseMaxConnectionMs: 300_000,
   // ... other options
 })
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@platformatic/mcp",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@platformatic/mcp",
-      "version": "1.2.2",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/mcp",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Scalable Fastify adapter for the Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/spec/authorization.md
+++ b/spec/authorization.md
@@ -4,8 +4,6 @@ title: Authorization
 
 <div id="enable-section-numbers" />
 
-<Info>**Protocol Revision**: 2025-06-18</Info>
-
 ## Introduction
 
 ### Purpose and Scope
@@ -36,10 +34,9 @@ while maintaining simplicity:
 - OAuth 2.0 Dynamic Client Registration Protocol
   ([RFC7591](https://datatracker.ietf.org/doc/html/rfc7591))
 - OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728))
+- OAuth Client ID Metadata Documents ([draft-ietf-oauth-client-id-metadata-document-00](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00))
 
-## Authorization Flow
-
-### Roles
+## Roles
 
 A protected _MCP server_ acts as an [OAuth 2.1 resource server](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#name-roles),
 capable of accepting and responding to protected resource requests using access tokens.
@@ -52,28 +49,33 @@ The implementation details of the authorization server are beyond the scope of t
 resource server or a separate entity. The [Authorization Server Discovery section](#authorization-server-discovery)
 specifies how an MCP server indicates the location of its corresponding authorization server to a client.
 
-### Overview
+## Overview
 
 1. Authorization servers **MUST** implement OAuth 2.1 with appropriate security
    measures for both confidential and public clients.
 
-1. Authorization servers and MCP clients **SHOULD** support the OAuth 2.0 Dynamic Client Registration
+2. Authorization servers and MCP clients **SHOULD** support OAuth Client ID Metadata Documents
+   ([draft-ietf-oauth-client-id-metadata-document-00](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00)).
+
+3. Authorization servers and MCP clients **MAY** support the OAuth 2.0 Dynamic Client Registration
    Protocol ([RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)).
 
-1. MCP servers **MUST** implement OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728)).
+4. MCP servers **MUST** implement OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728)).
    MCP clients **MUST** use OAuth 2.0 Protected Resource Metadata for authorization server discovery.
 
-1. Authorization servers **MUST** provide OAuth 2.0 Authorization
-   Server Metadata ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)).
-   MCP clients **MUST** use the OAuth 2.0 Authorization Server Metadata.
+5. MCP authorization servers **MUST** provide at least one of the following discovery mechanisms:
+   - OAuth 2.0 Authorization Server Metadata ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414))
+   - [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html)
 
-### Authorization Server Discovery
+   MCP clients **MUST** support both discovery mechanisms to obtain the information required to interact with the authorization server.
+
+## Authorization Server Discovery
 
 This section describes the mechanisms by which MCP servers advertise their associated
 authorization servers to MCP clients, as well as the discovery process through which MCP
 clients can determine authorization server endpoints and supported capabilities.
 
-#### Authorization Server Location
+### Authorization Server Location
 
 MCP servers **MUST** implement the OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728))
 specification to indicate the locations of authorization servers. The Protected Resource Metadata document returned by the MCP server **MUST** include
@@ -86,17 +88,62 @@ guidance on implementation details.
 Implementors should note that Protected Resource Metadata documents can define multiple authorization servers. The responsibility for selecting which authorization server to use lies with the MCP client, following the guidelines specified in
 [RFC9728 Section 7.6 "Authorization Servers"](https://datatracker.ietf.org/doc/html/rfc9728#name-authorization-servers).
 
-MCP servers **MUST** use the HTTP header `WWW-Authenticate` when returning a _401 Unauthorized_ to indicate the location of the resource server metadata URL
-as described in [RFC9728 Section 5.1 "WWW-Authenticate Response"](https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response).
+### Protected Resource Metadata Discovery Requirements
+
+MCP servers **MUST** implement one of the following discovery mechanisms to provide authorization server location information to MCP clients:
+
+1. **WWW-Authenticate Header**: Include the resource metadata URL in the `WWW-Authenticate` HTTP header under `resource_metadata` when returning `401 Unauthorized` responses, as described in [RFC9728 Section 5.1](https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response).
+
+2. **Well-Known URI**: Serve metadata at a well-known URI as specified in [RFC9728](https://datatracker.ietf.org/doc/html/rfc9728). This can be either:
+   - At the path of the server's MCP endpoint: `https://example.com/public/mcp` could host metadata at `https://example.com/.well-known/oauth-protected-resource/public/mcp`
+   - At the root: `https://example.com/.well-known/oauth-protected-resource`
+
+MCP clients **MUST** support both discovery mechanisms and use the resource metadata URL from the parsed `WWW-Authenticate` headers when present; otherwise, they **MUST** fall back to constructing and requesting the well-known URIs in the order listed above.
+
+MCP servers **SHOULD** include a `scope` parameter in the `WWW-Authenticate` header as defined in
+[RFC 6750 Section 3](https://datatracker.ietf.org/doc/html/rfc6750#section-3)
+to indicate the scopes required for accessing the resource. This provides clients with immediate
+guidance on the appropriate scopes to request during authorization,
+following the principle of least privilege and preventing clients from requesting excessive permissions.
+
+The scopes included in the `WWW-Authenticate` challenge **MAY** match `scopes_supported`, be a subset
+or superset of it, or an alternative collection that is neither a strict subset nor
+superset. Clients **MUST NOT** assume any particular set relationship between the challenged
+scope set and `scopes_supported`. Clients **MUST** treat the scopes provided in the
+challenge as authoritative for satisfying the current request. Servers **SHOULD** strive for
+consistency in how they construct scope sets but they are not required to surface every dynamically
+issued scope through `scopes_supported`.
+
+Example 401 response with scope guidance:
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource",
+                         scope="files:read"
+```
 
 MCP clients **MUST** be able to parse `WWW-Authenticate` headers and respond appropriately to `HTTP 401 Unauthorized` responses from the MCP server.
 
-#### Server Metadata Discovery
+If the `scope` parameter is absent, clients **SHOULD** apply the fallback behavior defined in the [Scope Selection Strategy](#scope-selection-strategy) section.
 
-MCP clients **MUST** follow the OAuth 2.0 Authorization Server Metadata [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)
-specification to obtain the information required to interact with the authorization server.
+### Authorization Server Metadata Discovery
 
-#### Sequence Diagram
+To handle different issuer URL formats and ensure interoperability with both OAuth 2.0 Authorization Server Metadata and OpenID Connect Discovery 1.0 specifications, MCP clients **MUST** attempt multiple well-known endpoints when discovering authorization server metadata.
+
+The discovery approach is based on [RFC8414 Section 3.1 "Authorization Server Metadata Request"](https://datatracker.ietf.org/doc/html/rfc8414#section-3.1) for OAuth 2.0 Authorization Server Metadata discovery and [RFC8414 Section 5 "Compatibility Notes"](https://datatracker.ietf.org/doc/html/rfc8414#section-5) for OpenID Connect Discovery 1.0 interoperability.
+
+For issuer URLs with path components (e.g., `https://auth.example.com/tenant1`), clients **MUST** try endpoints in the following priority order:
+
+1. OAuth 2.0 Authorization Server Metadata with path insertion: `https://auth.example.com/.well-known/oauth-authorization-server/tenant1`
+2. OpenID Connect Discovery 1.0 with path insertion: `https://auth.example.com/.well-known/openid-configuration/tenant1`
+3. OpenID Connect Discovery 1.0 path appending: `https://auth.example.com/tenant1/.well-known/openid-configuration`
+
+For issuer URLs without path components (e.g., `https://auth.example.com`), clients **MUST** try:
+
+1. OAuth 2.0 Authorization Server Metadata: `https://auth.example.com/.well-known/oauth-authorization-server`
+2. OpenID Connect Discovery 1.0: `https://auth.example.com/.well-known/openid-configuration`
+
+### Authorization Server Discovery Sequence Diagram
 
 The following diagram outlines an example flow:
 
@@ -106,15 +153,34 @@ sequenceDiagram
     participant M as MCP Server (Resource Server)
     participant A as Authorization Server
 
+    Note over C: Attempt unauthenticated MCP request
     C->>M: MCP request without token
-    M-->>C: HTTP 401 Unauthorized with WWW-Authenticate header
-    Note over C: Extract resource_metadata<br />from WWW-Authenticate
+    M-->>C: HTTP 401 Unauthorized (may include WWW-Authenticate header)
 
-    C->>M: GET /.well-known/oauth-protected-resource
-    M-->>C: Resource metadata with authorization server URL
+    alt Header includes resource_metadata
+        Note over C: Extract resource_metadata URL from header
+        C->>M: GET resource_metadata URI
+        M-->>C: Resource metadata with authorization server URL
+    else No resource_metadata in header
+        Note over C: Fallback to well-known URI probing
+        Note over M: _Not applicable if the MCP server is at the root_
+        C->>M: GET /.well-known/oauth-protected-resource/mcp
+        alt Sub-path metadata found
+            M-->>C: Resource metadata with authorization server URL
+        else Sub-path not found
+            C->>M: GET /.well-known/oauth-protected-resource
+            alt Root metadata found
+                M-->>C: Resource metadata with authorization server URL
+            else Root metadata not found
+                Note over C: Abort or use pre-configured values
+            end
+        end
+    end
+
     Note over C: Validate RS metadata,<br />build AS metadata URL
 
-    C->>A: GET /.well-known/oauth-authorization-server
+    C->>A: GET Authorization server metadata endpoint
+    Note over C,A: Try OAuth 2.0 and OpenID Connect<br/>discovery endpoints in priority order
     A-->>C: Authorization server metadata
 
     Note over C,A: OAuth 2.1 authorization flow happens here
@@ -127,22 +193,129 @@ sequenceDiagram
     Note over C,M: MCP communication continues with valid token
 ```
 
-### Dynamic Client Registration
+## Client Registration Approaches
 
-MCP clients and authorization servers **SHOULD** support the
-OAuth 2.0 Dynamic Client Registration Protocol [RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)
-to allow MCP clients to obtain OAuth client IDs without user interaction. This provides a
-standardized way for clients to automatically register with new authorization servers, which is crucial
-for MCP because:
+MCP supports three client registration mechanisms. Choose based on your scenario:
 
-- Clients may not know all possible MCP servers and their authorization servers in advance.
-- Manual registration would create friction for users.
-- It enables seamless connection to new MCP servers and their authorization servers.
-- Authorization servers can implement their own registration policies.
+- **Client ID Metadata Documents**: When client and server have no prior relationship (most common)
+- **Pre-registration**: When client and server have an existing relationship
+- **Dynamic Client Registration**: For backwards compatibility or specific requirements
 
-Any authorization servers that _do not_ support Dynamic Client Registration need to provide
-alternative ways to obtain a client ID (and, if applicable, client credentials). For one of
-these authorization servers, MCP clients will have to either:
+Clients supporting all options **SHOULD** follow the following priority order:
+
+1. Use pre-registered client information for the server if the client has it available
+2. Use Client ID Metadata Documents if the Authorization Server indicates if the server supports it (via `client_id_metadata_document_supported` in OAuth Authorization Server Metadata)
+3. Use Dynamic Client Registration as a fallback if the Authorization Server supports it (via `registration_endpoint` in OAuth Authorization Server Metadata)
+4. Prompt the user to enter the client information if no other option is available
+
+### Client ID Metadata Documents
+
+MCP clients and authorization servers **SHOULD** support OAuth Client ID Metadata Documents as specified in
+[OAuth Client ID Metadata Document](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00).
+This approach enables clients to use HTTPS URLs as client identifiers, where the URL points to a JSON document
+containing client metadata. This addresses the common MCP scenario where servers and clients have
+no pre-existing relationship.
+
+#### Implementation Requirements
+
+MCP implementations supporting Client ID Metadata Documents **MUST** follow the requirements specified in
+[OAuth Client ID Metadata Document](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00).
+Key requirements include:
+
+**For MCP Clients:**
+
+- Clients **MUST** host their metadata document at an HTTPS URL following RFC requirements
+- The `client_id` URL **MUST** use the "https" scheme and contain a path component, e.g. `https://example.com/client.json`
+- The metadata document **MUST** include at least the following properties: `client_id`, `client_name`, `redirect_uris`
+- Clients **MUST** ensure the `client_id` value in the metadata matches the document URL exactly
+- Clients **MAY** use `private_key_jwt` for client authentication (e.g., for requests to the token endpoint) with appropriate JWKS configuration as described in [Section 6.2 of Client ID Metadata Document](https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-00.html#section-6.2)
+
+**For Authorization Servers:**
+
+- **SHOULD** fetch metadata documents when encountering URL-formatted client_ids
+- **MUST** validate that the fetched document's `client_id` matches the URL exactly
+- **SHOULD** cache metadata respecting HTTP cache headers
+- **MUST** validate redirect URIs presented in an authorization request against those in the metadata document
+- **MUST** validate the document structure is valid JSON and contains required fields
+- **SHOULD** follow the security considerations in [Section 6 of Client ID Metadata Document](https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-00.html#section-6)
+
+#### Example Metadata Document
+
+```json
+{
+  "client_id": "https://app.example.com/oauth/client-metadata.json",
+  "client_name": "Example MCP Client",
+  "client_uri": "https://app.example.com",
+  "logo_uri": "https://app.example.com/logo.png",
+  "redirect_uris": [
+    "http://127.0.0.1:3000/callback",
+    "http://localhost:3000/callback"
+  ],
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+#### Client ID Metadata Documents Flow
+
+The following diagram illustrates the complete flow when using Client ID Metadata Documents:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Client as MCP Client
+    participant Server as Authorization Server
+    participant Metadata as Metadata Endpoint<br/>(Client's HTTPS URL)
+    participant Resource as MCP Server
+
+    Note over Client,Metadata: Client hosts metadata at<br/>https://app.example.com/oauth/metadata.json
+
+    User->>Client: Initiates connection to MCP Server
+    Client->>Server: Authorization Request<br/>client_id=https://app.example.com/oauth/metadata.json<br/>redirect_uri=http://localhost:3000/callback
+
+    Server->>User: Authentication prompt
+    User->>Server: Provides credentials
+    Note over Server: Authenticates user
+
+    Note over Server: Detects URL-formatted client_id
+
+    Server->>Metadata: GET https://app.example.com/oauth/metadata.json
+    Metadata-->>Server: JSON Metadata Document<br/>{client_id, client_name, redirect_uris, ...}
+
+    Note over Server: Validates:<br/>1. client_id matches URL<br/>2. redirect_uri in allowed list<br/>3. Document structure valid<br/>4. (Optional) Domain allowed via trust policy
+
+    alt Validation Success
+        Server->>User: Display consent page with client_name
+        User->>Server: Approves access
+        Server->>Client: Authorization code via redirect_uri
+        Client->>Server: Exchange code for token<br/>client_id=https://app.example.com/oauth/metadata.json
+        Server-->>Client: Access token
+        Client->>Resource: MCP requests with access token
+        Resource-->>Client: MCP responses
+    else Validation Failure
+        Server->>User: Error response<br/>error=invalid_client or invalid_request
+    end
+
+    Note over Server: Cache metadata for future requests<br/>(respecting HTTP cache headers)
+```
+
+#### Discovery
+
+Authorization servers advertise that they support clients using Client ID Metadata Documents by including the following property in their OAuth Authorization Server metadata:
+
+```json
+{
+  "client_id_metadata_document_supported": true
+}
+```
+
+MCP clients **SHOULD** check for this capability and **MAY** fall back to Dynamic Client Registration
+or pre-registration if unavailable.
+
+### Preregistration
+
+MCP clients **SHOULD** support an option for static client credentials such as those supplied by a preregistration flow. This could be:
 
 1. Hardcode a client ID (and, if applicable, client credentials) specifically for the MCP client to use when
    interacting with that authorization server, or
@@ -150,7 +323,31 @@ these authorization servers, MCP clients will have to either:
    OAuth client themselves (e.g., through a configuration interface hosted by the
    server).
 
-### Authorization Flow Steps
+### Dynamic Client Registration
+
+MCP clients and authorization servers **MAY** support the
+OAuth 2.0 Dynamic Client Registration Protocol [RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)
+to allow MCP clients to obtain OAuth client IDs without user interaction.
+This option is included for backwards compatibility with earlier versions of the MCP authorization spec.
+
+## Scope Selection Strategy
+
+When implementing authorization flows, MCP clients **SHOULD** follow the principle of least privilege by requesting
+only the scopes necessary for their intended operations. During the initial authorization handshake, MCP clients
+**SHOULD** follow this priority order for scope selection:
+
+1. **Use `scope` parameter** from the initial `WWW-Authenticate` header in the 401 response, if provided
+2. **If `scope` is not available**, use all scopes defined in `scopes_supported` from the Protected Resource Metadata document, omitting the `scope` parameter if `scopes_supported` is undefined.
+
+This approach accommodates the general-purpose nature of MCP clients, which typically lack domain-specific knowledge to make informed decisions about individual scope selection. Requesting all available scopes allows the authorization server and end-user to determine appropriate permissions during the consent process.
+
+This approach minimizes user friction while following the principle of least privilege.
+The `scopes_supported` field is intended to represent the minimal set of scopes necessary
+for basic functionality (see [Scope Minimization](/specification/2025-11-25/basic/security_best_practices#scope-minimization)),
+with additional scopes requested incrementally through the step-up authorization flow steps
+described in the [Scope Challenge Handling](#scope-challenge-handling) section.
+
+## Authorization Flow Steps
 
 The complete Authorization flow proceeds as follows:
 
@@ -170,15 +367,24 @@ sequenceDiagram
 
     Note over C: Parse metadata and extract authorization server(s)<br/>Client determines AS to use
 
-    C->>A: GET /.well-known/oauth-authorization-server
-    A->>C: Authorization server metadata response
+    C->>A: GET Authorization server metadata endpoint
+    Note over C,A: Try OAuth 2.0 and OpenID Connect<br/>discovery endpoints in priority order
+    A-->>C: Authorization server metadata
 
-    alt Dynamic client registration
+    alt Client ID Metadata Documents
+        Note over C: Client uses HTTPS URL as client_id
+        Note over A: Server detects URL-formatted client_id
+        A->>C: Fetch metadata from client_id URL
+        C-->>A: JSON metadata document
+        Note over A: Validate metadata and redirect_uris
+    else Dynamic client registration
         C->>A: POST /register
         A->>C: Client Credentials
+    else Pre-registered client
+        Note over C: Use existing client_id
     end
 
-    Note over C: Generate PKCE parameters<br/>Include resource parameter
+    Note over C: Generate PKCE parameters<br/>Include resource parameter<br/>Apply scope selection strategy
     C->>B: Open browser with authorization URL + code_challenge + resource
     B->>A: Authorization request with resource parameter
     Note over A: User authorizes
@@ -191,7 +397,7 @@ sequenceDiagram
     Note over C,M: MCP communication continues with valid token
 ```
 
-#### Resource Parameter Implementation
+## Resource Parameter Implementation
 
 MCP clients **MUST** implement Resource Indicators for OAuth 2.0 as defined in [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)
 to explicitly specify the target resource for which the token is being requested. The `resource` parameter:
@@ -200,7 +406,7 @@ to explicitly specify the target resource for which the token is being requested
 2. **MUST** identify the MCP server that the client intends to use the token with.
 3. **MUST** use the canonical URI of the MCP server as defined in [RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#name-access-token-request).
 
-##### Canonical Server URI
+### Canonical Server URI
 
 For the purposes of this specification, the canonical URI of an MCP server is defined as the resource identifier as specified in
 [RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#section-2) and aligns with the `resource` parameter in
@@ -230,9 +436,9 @@ For example, if accessing an MCP server at `https://mcp.example.com`, the author
 
 MCP clients **MUST** send this parameter regardless of whether authorization servers support it.
 
-### Access Token Usage
+## Access Token Usage
 
-#### Token Requirements
+### Token Requirements
 
 Access token handling when making requests to MCP servers **MUST** conform to the requirements defined in
 [OAuth 2.1 Section 5 "Resource Requests"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5).
@@ -258,7 +464,7 @@ Host: mcp.example.com
 Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
 ```
 
-#### Token Handling
+### Token Handling
 
 MCP servers, acting in their role as an OAuth 2.1 resource server, **MUST** validate access tokens as described in
 [OAuth 2.1 Section 5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5.2).
@@ -271,12 +477,12 @@ response.
 
 MCP clients **MUST NOT** send tokens to the MCP server other than ones issued by the MCP server's authorization server.
 
-Authorization servers **MUST** only accept tokens that are valid for use with their
+MCP servers **MUST** only accept tokens that are valid for use with their
 own resources.
 
 MCP servers **MUST NOT** accept or transit any other tokens.
 
-### Error Handling
+## Error Handling
 
 Servers **MUST** return appropriate HTTP status codes for authorization errors:
 
@@ -285,6 +491,69 @@ Servers **MUST** return appropriate HTTP status codes for authorization errors:
 | 401         | Unauthorized | Authorization required or token invalid    |
 | 403         | Forbidden    | Invalid scopes or insufficient permissions |
 | 400         | Bad Request  | Malformed authorization request            |
+
+### Scope Challenge Handling
+
+This section covers handling insufficient scope errors during runtime operations when
+a client already has a token but needs additional permissions. This follows the error
+handling patterns defined in [OAuth 2.1 Section 5](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5)
+and leverages the metadata fields from [RFC 9728 (OAuth 2.0 Protected Resource Metadata)](https://datatracker.ietf.org/doc/html/rfc9728).
+
+#### Runtime Insufficient Scope Errors
+
+When a client makes a request with an access token with insufficient
+scope during runtime operations, the server **SHOULD** respond with:
+
+- `HTTP 403 Forbidden` status code (per [RFC 6750 Section 3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1))
+- `WWW-Authenticate` header with the `Bearer` scheme and additional parameters:
+  - `error="insufficient_scope"` - indicating the specific type of authorization failure
+  - `scope="required_scope1 required_scope2"` - specifying the minimum scopes needed for the operation
+  - `resource_metadata` - the URI of the Protected Resource Metadata document (for consistency with 401 responses)
+  - `error_description` (optional) - human-readable description of the error
+
+**Server Scope Management**: When responding with insufficient scope errors, servers
+**SHOULD** include the scopes needed to satisfy the current request in the `scope`
+parameter.
+
+Servers have flexibility in determining which scopes to include:
+
+- **Minimum approach**: Include the newly-required scopes for the specific operation. Include any existing granted scopes as well, if they are required, to prevent clients from losing previously granted permissions.
+- **Recommended approach**: Include both existing relevant scopes and newly required scopes to prevent clients from losing previously granted permissions
+- **Extended approach**: Include existing scopes, newly required scopes, and related scopes that commonly work together
+
+The choice depends on the server's assessment of user experience impact and authorization friction.
+
+Servers **SHOULD** be consistent in their scope inclusion strategy to provide predictable behavior for clients.
+
+Servers **SHOULD** consider the user experience impact when determining which scopes to include in the
+response, as misconfigured scopes may require frequent user interaction.
+
+Example insufficient scope response:
+
+```http
+HTTP/1.1 403 Forbidden
+WWW-Authenticate: Bearer error="insufficient_scope",
+                         scope="files:read files:write user:profile",
+                         resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource",
+                         error_description="Additional file write permission required"
+```
+
+#### Step-Up Authorization Flow
+
+Clients will receive scope-related errors during initial authorization or at runtime (`insufficient_scope`).
+Clients **SHOULD** respond to these errors by requesting a new access token with an increased set of scopes via a step-up authorization flow or handle the errors in other, appropriate ways.
+Clients acting on behalf of a user **SHOULD** attempt the step-up authorization flow. Clients acting on their own behalf (`client_credentials` clients)
+**MAY** attempt the step-up authorization flow or abort the request immediately.
+
+The flow is as follows:
+
+1. **Parse error information** from the authorization server response or `WWW-Authenticate` header
+2. **Determine required scopes** as outlined in [Scope Selection Strategy](#scope-selection-strategy).
+3. **Initiate (re-)authorization** with the determined scope set
+4. **Retry the original request** with the new authorization no more than a few times and treat this as a permanent authorization failure
+
+Clients **SHOULD** implement retry limits and **SHOULD** track scope upgrade attempts to avoid
+repeated failures for the same resource and operation combination.
 
 ## Security Considerations
 
@@ -298,7 +567,7 @@ audiences **when the Authorization Server supports the capability**. To enable c
 - MCP clients **MUST** include the `resource` parameter in authorization and token requests as specified in the [Resource Parameter Implementation](#resource-parameter-implementation) section
 - MCP servers **MUST** validate that tokens presented to them were specifically issued for their use
 
-The [Security Best Practices document](/specification/2025-06-18/basic/security_best_practices#token-passthrough)
+The [Security Best Practices document](/specification/2025-11-25/basic/security_best_practices#token-passthrough)
 outlines why token audience validation is crucial and why token passthrough is explicitly forbidden.
 
 ### Token Theft
@@ -326,8 +595,18 @@ Specifically:
 An attacker who has gained access to an authorization code contained in an authorization response can try to redeem the authorization code for an access token or otherwise make use of the authorization code.
 (Further described in [OAuth 2.1 Section 7.5](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.5))
 
-To mitigate this, MCP clients **MUST** implement PKCE according to [OAuth 2.1 Section 7.5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.5.2).
+To mitigate this, MCP clients **MUST** implement PKCE according to [OAuth 2.1 Section 7.5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.5.2) and **MUST** verify PKCE support before proceeding with authorization.
 PKCE helps prevent authorization code interception and injection attacks by requiring clients to create a secret verifier-challenge pair, ensuring that only the original requestor can exchange an authorization code for tokens.
+
+MCP clients **MUST** use the `S256` code challenge method when technically capable, as required by [OAuth 2.1 Section 4.1.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-4.1.1).
+
+Since OAuth 2.1 and PKCE specifications do not define a mechanism for clients to discover PKCE support, MCP clients **MUST** rely on authorization server metadata to verify this capability:
+
+- **OAuth 2.0 Authorization Server Metadata**: If `code_challenge_methods_supported` is absent, the authorization server does not support PKCE and MCP clients **MUST** refuse to proceed.
+
+- **OpenID Connect Discovery 1.0**: While the [OpenID Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) does not define `code_challenge_methods_supported`, this field is commonly included by OpenID providers. MCP clients **MUST** verify the presence of `code_challenge_methods_supported` in the provider metadata response. If the field is absent, MCP clients **MUST** refuse to proceed.
+
+Authorization servers providing OpenID Connect Discovery 1.0 **MUST** include `code_challenge_methods_supported` in their metadata to ensure MCP compatibility.
 
 ### Open Redirection
 
@@ -344,9 +623,52 @@ Authorization servers **MUST** take precautions to prevent redirecting user agen
 
 Authorization servers **SHOULD** only automatically redirect the user agent if it trusts the redirection URI. If the URI is not trusted, the authorization server MAY inform the user and rely on the user to make the correct decision.
 
+### Client ID Metadata Document Security
+
+When implementing Client ID Metadata Documents, authorization servers **MUST** consider the security implications
+detailed in [OAuth Client ID Metadata Document, Section 6](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00#name-security-considerations).
+Key considerations include:
+
+#### Authorization Server Abuse Protection
+
+The authorization server takes a URL as input from an unknown client and fetches that URL.
+A malicious client could use this to trigger the authorization server to make requests to arbitrary URLs,
+such as requests to private administration endpoints the authorization server has access to.
+
+Authorization servers fetching metadata documents **SHOULD** consider
+[Server-Side Request Forgery (SSRF)](https://developer.mozilla.org/docs/Web/Security/Attacks/SSRF) risks, as described in [OAuth Client ID Metadata Document: Server Side Request Forgery (SSRF) Attacks](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00#name-server-side-request-forgery).
+
+#### Localhost Redirect URI Risks
+
+Client ID Metadata Documents cannot prevent `localhost` URL impersonation by themselves. An attacker can claim to be any client by:
+
+1. Providing the legitimate client's metadata URL as their `client_id`
+2. Binding to the any `localhost` port, and providing that address as the redirect_uri
+3. Receiving the authorization code via the redirect when the user approves
+
+The server will see the legitimate client's metadata document and the user will see the legitimate client's name, making attack detection difficult.
+
+Authorization servers:
+
+- **SHOULD** display additional warnings for `localhost`-only redirect URIs
+- **MAY** require additional attestation mechanisms for enhanced security
+- **MUST** clearly display the redirect URI hostname during authorization
+
+#### Trust Policies
+
+Authorization servers **MAY** implement domain-based trust policies:
+
+- Allowlists for trusted domains (for protected servers)
+- Accept any HTTPS `client_id` (for open servers)
+- Reputation checks for unknown domains
+- Restrictions based on domain age or certificate validation
+- Display the CIMD and other associated client hostnames prominently to prevent phishing
+
+Servers maintain full control over their access policies.
+
 ### Confused Deputy Problem
 
-Attackers can exploit MCP servers acting as intermediaries to third-party APIs, leading to [confused deputy vulnerabilities](/specification/2025-06-18/basic/security_best_practices#confused-deputy-problem).
+Attackers can exploit MCP servers acting as intermediaries to third-party APIs, leading to [confused deputy vulnerabilities](/specification/2025-11-25/basic/security_best_practices#confused-deputy-problem).
 By using stolen authorization codes, they can obtain access tokens without user consent.
 
 MCP proxy servers using static client IDs **MUST** obtain user consent for each dynamically
@@ -354,22 +676,33 @@ registered client before forwarding to third-party authorization servers (which 
 
 ### Access Token Privilege Restriction
 
-An attacker can gain unauthorized access or otherwise compromise a MCP server if the server accepts tokens issued for other resources.
+An attacker can gain unauthorized access or otherwise compromise an MCP server if the server accepts tokens issued for other resources.
 
 This vulnerability has two critical dimensions:
 
 1. **Audience validation failures.** When an MCP server doesn't verify that tokens were specifically intended for it (for example, via the audience claim, as mentioned in [RFC9068](https://www.rfc-editor.org/rfc/rfc9068.html)), it may accept tokens originally issued for other services. This breaks a fundamental OAuth security boundary, allowing attackers to reuse legitimate tokens across different services than intended.
-2. **Token passthrough.** If the MCP server not only accepts tokens with incorrect audiences but also forwards these unmodified tokens to downstream services, it can potentially cause the ["confused deputy" problem](#confused-deputy-problem), where the downstream API may incorrectly trust the token as if it came from the MCP server or assume the token was validated by the upstream API. See the [Token Passthrough section](/specification/2025-06-18/basic/security_best_practices#token-passthrough) of the Security Best Practices guide for additional details.
+2. **Token passthrough.** If the MCP server not only accepts tokens with incorrect audiences but also forwards these unmodified tokens to downstream services, it can potentially cause the ["confused deputy" problem](#confused-deputy-problem), where the downstream API may incorrectly trust the token as if it came from the MCP server or assume the token was validated by the upstream API. See the [Token Passthrough section](/specification/2025-11-25/basic/security_best_practices#token-passthrough) of the Security Best Practices guide for additional details.
 
 MCP servers **MUST** validate access tokens before processing the request, ensuring the access token is issued specifically for the MCP server, and take all necessary steps to ensure no data is returned to unauthorized parties.
 
 A MCP server **MUST** follow the guidelines in [OAuth 2.1 - Section 5.2](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#section-5.2) to validate inbound tokens.
 
-MCP servers **MUST** only accept tokens specifically intended for themselves and **MUST** reject tokens that do not include them in the audience claim or otherwise verify that they are the intended recipient of the token. See the [Security Best Practices Token Passthrough section](/specification/2025-06-18/basic/security_best_practices#token-passthrough) for details.
+MCP servers **MUST** only accept tokens specifically intended for themselves and **MUST** reject tokens that do not include them in the audience claim or otherwise verify that they are the intended recipient of the token. See the [Security Best Practices Token Passthrough section](/specification/2025-11-25/basic/security_best_practices#token-passthrough) for details.
 
-If the MCP server makes requests to upstream APIs, it may act as an OAuth client to them. The access token used at the upstream API is a seperate token, issued by the upstream authorization server. The MCP server **MUST NOT** pass through the token it received from the MCP client.
+If the MCP server makes requests to upstream APIs, it may act as an OAuth client to them. The access token used at the upstream API is a separate token, issued by the upstream authorization server. The MCP server **MUST NOT** pass through the token it received from the MCP client.
 
 MCP clients **MUST** implement and use the `resource` parameter as defined in [RFC 8707 - Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707.html)
 to explicitly specify the target resource for which the token is being requested. This requirement aligns with the recommendation in
 [RFC 9728 Section 7.4](https://datatracker.ietf.org/doc/html/rfc9728#section-7.4). This ensures that access tokens are bound to their intended resources and
 cannot be misused across different services.
+
+## MCP Authorization Extensions
+
+There are several authorization extensions to the core protocol that define additional authorization mechanisms. These extensions are:
+
+- **Optional** - Implementations can choose to adopt these extensions
+- **Additive** - Extensions do not modify or break core protocol functionality; they add new capabilities while preserving core protocol behavior
+- **Composable** - Extensions are modular and designed to work together without conflicts, allowing implementations to adopt multiple extensions simultaneously
+- **Versioned independently** - Extensions follow the core MCP versioning cycle but may adopt independent versioning as needed
+
+A list of supported extensions can be found in the [MCP Authorization Extensions](https://github.com/modelcontextprotocol/ext-auth) repository.

--- a/spec/basic.md
+++ b/spec/basic.md
@@ -4,8 +4,6 @@ title: Overview
 
 <div id="enable-section-numbers" />
 
-<Info>**Protocol Revision**: 2025-06-18</Info>
-
 The Model Context Protocol consists of several key components that work together:
 
 - **Base Protocol**: Core JSON-RPC message types
@@ -32,7 +30,7 @@ these types of messages:
 
 ### Requests
 
-Requests are sent from the client to the server or vice versa, to initiate an operation.
+[Requests](/specification/2025-11-25/schema#jsonrpcrequest) are sent from the client to the server or vice versa, to initiate an operation.
 
 ```typescript
 {
@@ -52,16 +50,35 @@ Requests are sent from the client to the server or vice versa, to initiate an op
 
 ### Responses
 
-Responses are sent in reply to requests, containing the result or error of the operation.
+Responses are sent in reply to requests, containing either the result or error of the operation.
+
+#### Result Responses
+
+[Result responses](/specification/2025-11-25/schema#jsonrpcresultresponse) are sent when the operation completes successfully.
 
 ```typescript
 {
   jsonrpc: "2.0";
   id: string | number;
-  result?: {
+  result: {
     [key: string]: unknown;
   }
-  error?: {
+}
+```
+
+- Result responses **MUST** include the same ID as the request they correspond to.
+- Result responses **MUST** include a `result` field.
+- The `result` **MAY** follow any JSON object structure.
+
+#### Error Responses
+
+[Error responses](/specification/2025-11-25/schema#jsonrpcerrorresponse) are sent when the operation fails or encounters an error.
+
+```typescript
+{
+  jsonrpc: "2.0";
+  id?: string | number;
+  error: {
     code: number;
     message: string;
     data?: unknown;
@@ -69,17 +86,13 @@ Responses are sent in reply to requests, containing the result or error of the o
 }
 ```
 
-- Responses **MUST** include the same ID as the request they correspond to.
-- **Responses** are further sub-categorized as either **successful results** or
-  **errors**. Either a `result` or an `error` **MUST** be set. A response **MUST NOT**
-  set both.
-- Results **MAY** follow any JSON object structure, while errors **MUST** include an
-  error code and message at minimum.
+- Error responses **MUST** include the same ID as the request they correspond to (except in error cases where the ID could not be read due a malformed request).
+- Error responses **MUST** include an `error` field with a `code` and `message`.
 - Error codes **MUST** be integers.
 
 ### Notifications
 
-Notifications are sent from the client to the server or vice versa, as a one-way message.
+[Notifications](/specification/2025-11-25/schema#jsonrpcnotification) are sent from the client to the server or vice versa, as a one-way message.
 The receiver **MUST NOT** send a response.
 
 ```typescript
@@ -96,7 +109,7 @@ The receiver **MUST NOT** send a response.
 
 ## Auth
 
-MCP provides an [Authorization](/specification/2025-06-18/basic/authorization) framework for use with HTTP.
+MCP provides an [Authorization](/specification/2025-11-25/basic/authorization) framework for use with HTTP.
 Implementations using an HTTP-based transport **SHOULD** conform to this specification,
 whereas implementations using STDIO transport **SHOULD NOT** follow this specification,
 and instead retrieve credentials from the environment.
@@ -104,7 +117,7 @@ and instead retrieve credentials from the environment.
 Additionally, clients and servers **MAY** negotiate their own custom authentication and
 authorization strategies.
 
-For further discussions and contributions to the evolution of MCP’s auth mechanisms, join
+For further discussions and contributions to the evolution of MCP's auth mechanisms, join
 us in
 [GitHub Discussions](https://github.com/modelcontextprotocol/specification/discussions)
 to help shape the future of the protocol!
@@ -112,17 +125,69 @@ to help shape the future of the protocol!
 ## Schema
 
 The full specification of the protocol is defined as a
-[TypeScript schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-06-18/schema.ts).
+[TypeScript schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-11-25/schema.ts).
 This is the source of truth for all protocol messages and structures.
 
 There is also a
-[JSON Schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-06-18/schema.json),
+[JSON Schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-11-25/schema.json),
 which is automatically generated from the TypeScript source of truth, for use with
 various automated tooling.
 
-### General fields
+## JSON Schema Usage
 
-#### `_meta`
+The Model Context Protocol uses JSON Schema for validation throughout the protocol. This section clarifies how JSON Schema should be used within MCP messages.
+
+### Schema Dialect
+
+MCP supports JSON Schema with the following rules:
+
+1. **Default dialect**: When a schema does not include a `$schema` field, it defaults to [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/schema)
+1. **Explicit dialect**: Schemas MAY include a `$schema` field to specify a different dialect
+1. **Supported dialects**: Implementations MUST support at least 2020-12 and SHOULD document which additional dialects they support
+1. **Recommendation**: Implementors are RECOMMENDED to use JSON Schema 2020-12.
+
+### Example Usage
+
+#### Default dialect (2020-12):
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer", "minimum": 0 }
+  },
+  "required": ["name"]
+}
+```
+
+#### Explicit dialect (draft-07):
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer", "minimum": 0 }
+  },
+  "required": ["name"]
+}
+```
+
+### Implementation Requirements
+
+- Clients and servers **MUST** support JSON Schema 2020-12 for schemas without an explicit `$schema` field
+- Clients and servers **MUST** validate schemas according to their declared or default dialect. They **MUST** handle unsupported dialects gracefully by returning an appropriate error indicating the dialect is not supported.
+- Clients and servers **SHOULD** document which schema dialects they support
+
+### Schema Validation
+
+- Schemas **MUST** be valid according to their declared or default dialect
+
+## General fields
+
+### `_meta`
 
 The `_meta` property/parameter is reserved by MCP to allow clients and servers
 to attach additional metadata to their interactions.
@@ -130,7 +195,7 @@ to attach additional metadata to their interactions.
 Certain key names are reserved by MCP for protocol-level metadata, as specified below;
 implementations MUST NOT make assumptions about values at these keys.
 
-Additionally, definitions in the [schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-06-18/schema.ts)
+Additionally, definitions in the [schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-11-25/schema.ts)
 may reserve particular names for purpose-specific metadata, as declared in those definitions.
 
 **Key name format:** valid `_meta` key names have two segments: an optional **prefix**, and a **name**.
@@ -139,11 +204,64 @@ may reserve particular names for purpose-specific metadata, as declared in those
 
 - If specified, MUST be a series of labels separated by dots (`.`), followed by a slash (`/`).
   - Labels MUST start with a letter and end with a letter or digit; interior characters can be letters, digits, or hyphens (`-`).
-- Any prefix beginning with zero or more valid labels, followed by `modelcontextprotocol` or `mcp`, followed by any valid label,
-  is **reserved** for MCP use.
-  - For example: `modelcontextprotocol.io/`, `mcp.dev/`, `api.modelcontextprotocol.org/`, and `tools.mcp.com/` are all reserved.
+  - Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).
+- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use.
+  - For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved.
+  - However, `com.example.mcp/` is NOT reserved, as the second label is `example`.
 
 **Name:**
 
 - Unless empty, MUST begin and end with an alphanumeric character (`[a-z0-9A-Z]`).
 - MAY contain hyphens (`-`), underscores (`_`), dots (`.`), and alphanumerics in between.
+
+### `icons`
+
+The `icons` property provides a standardized way for servers to expose visual identifiers for their resources, tools, prompts, and implementations. Icons enhance user interfaces by providing visual context and improving the discoverability of available functionality.
+
+Icons are represented as an array of `Icon` objects, where each icon includes:
+
+- `src`: A URI pointing to the icon resource (required). This can be:
+  - An HTTP/HTTPS URL pointing to an image file
+  - A data URI with base64-encoded image data
+- `mimeType`: Optional MIME type if the server's type is missing or generic
+- `sizes`: Optional array of size specifications (e.g., `["48x48"]`, `["any"]` for scalable formats like SVG, or `["48x48", "96x96"]` for multiple sizes)
+- `theme`: Optional theme preference (`light` or `dark`) for the icon background
+
+**Required MIME type support:**
+
+Clients that support rendering icons **MUST** support at least the following MIME types:
+
+- `image/png` - PNG images (safe, universal compatibility)
+- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)
+
+Clients that support rendering icons **SHOULD** also support:
+
+- `image/svg+xml` - SVG images (scalable but requires security precautions as noted below)
+- `image/webp` - WebP images (modern, efficient format)
+
+**Security considerations:**
+
+Consumers of icon metadata **MUST** take appropriate security precautions when handling icons to prevent compromise:
+
+- Treat icon metadata and icon bytes as untrusted inputs and defend against network, privacy, and parsing risks.
+- Ensure that the icon URI is either a HTTPS or `data:` URI. Clients **MUST** reject icon URIs that use unsafe schemes and redirects, such as `javascript:`, `file:`, `ftp:`, `ws:`, or local app URI schemes.
+  - Disallow scheme changes and redirects to hosts on different origins.
+- Be resilient against resource exhaustion attacks stemming from oversized images, large dimensions, or excessive frames (e.g., in GIFs).
+  - Consumers **MAY** set limits for image and content size.
+- Fetch icons without credentials. Do not send cookies, `Authorization` headers, or client credentials.
+- Verify that icon URIs are from the same origin as the server. This minimizes the risk of exposing data or tracking information to third-parties.
+- Exercise caution when fetching and rendering icons as the payload **MAY** contain executable content (e.g., SVG with [embedded JavaScript](https://www.w3.org/TR/SVG11/script.html) or [extended capabilities](https://www.w3.org/TR/SVG11/extend.html)).
+  - Consumers **MAY** choose to disallow specific file types or otherwise sanitize icon files before rendering.
+- Validate MIME types and file contents before rendering. Treat the MIME type information as advisory. Detect content type via magic bytes; reject on mismatch or unknown types.
+  - Maintain a strict allowlist of image types.
+
+**Usage:**
+
+Icons can be attached to:
+
+- `Implementation`: Visual identifier for the MCP server/client implementation
+- `Tool`: Visual representation of the tool's functionality
+- `Prompt`: Icon to display alongside prompt templates
+- `Resource`: Visual indicator for different resource types
+
+Multiple icons can be provided to support different display contexts and resolutions. Clients should select the most appropriate icon based on their UI requirements.

--- a/spec/cancellation.md
+++ b/spec/cancellation.md
@@ -4,8 +4,6 @@ title: Cancellation
 
 <div id="enable-section-numbers" />
 
-<Info>**Protocol Revision**: 2025-06-18</Info>
-
 The Model Context Protocol (MCP) supports optional cancellation of in-progress requests
 through notification messages. Either side can send a cancellation notification to
 indicate that a previously-issued request should be terminated.
@@ -34,16 +32,17 @@ notification containing:
 1. Cancellation notifications **MUST** only reference requests that:
    - Were previously issued in the same direction
    - Are believed to still be in-progress
-2. The `initialize` request **MUST NOT** be cancelled by clients
-3. Receivers of cancellation notifications **SHOULD**:
+1. The `initialize` request **MUST NOT** be cancelled by clients
+1. For [task-augmented requests](./tasks), the `tasks/cancel` request **MUST** be used instead of the `notifications/cancelled` notification. Tasks have their own dedicated cancellation mechanism that returns the final task state.
+1. Receivers of cancellation notifications **SHOULD**:
    - Stop processing the cancelled request
    - Free associated resources
    - Not send a response for the cancelled request
-4. Receivers **MAY** ignore cancellation notifications if:
+1. Receivers **MAY** ignore cancellation notifications if:
    - The referenced request is unknown
    - Processing has already completed
    - The request cannot be cancelled
-5. The sender of the cancellation notification **SHOULD** ignore any response to the
+1. The sender of the cancellation notification **SHOULD** ignore any response to the
    request that arrives afterward
 
 ## Timing Considerations

--- a/spec/elicitation.md
+++ b/spec/elicitation.md
@@ -4,19 +4,15 @@ title: Elicitation
 
 <div id="enable-section-numbers" />
 
-<Info>**Protocol Revision**: 2025-06-18</Info>
-
-<Note>
-
-Elicitation is newly introduced in this version of the MCP specification and its design may evolve in future protocol versions.
-
-</Note>
-
 The Model Context Protocol (MCP) provides a standardized way for servers to request additional
 information from users through the client during interactions. This flow allows clients to
 maintain control over user interactions and data sharing while enabling servers to gather
 necessary information dynamically.
-Servers request structured data from users with JSON schemas to validate responses.
+
+Elicitation supports two modes:
+
+- **Form mode**: Servers can request structured data from users with optional JSON schemas to validate responses
+- **URL mode**: Servers can direct users to external URLs for sensitive interactions that must _not_ pass through the MCP client
 
 ## User Interaction Model
 
@@ -31,36 +27,214 @@ model.
 
 For trust & safety and security:
 
-- Servers **MUST NOT** use elicitation to request sensitive information.
+- Servers **MUST NOT** use form mode elicitation to request sensitive information such as
+  passwords, API keys, access tokens, or payment credentials
+- Servers **MUST** use [URL mode](#url-mode-elicitation-requests) for interactions involving
+  such sensitive information
 
-Applications **SHOULD**:
+"Sensitive information" in this context refers to secrets and credentials that grant access or
+authorize transactions. General contact or profile information (such as a name, email address,
+or username) is not categorically prohibited; whether to request such data via form mode is at
+the discretion of the server and subject to the user's ability to review and decline.
+
+MCP clients **MUST**:
 
 - Provide UI that makes it clear which server is requesting information
-- Allow users to review and modify their responses before sending
 - Respect user privacy and provide clear decline and cancel options
+- For form mode, allow users to review and modify their responses before sending
+- For URL mode, clearly display the target domain/host and gather user consent before navigation to the target URL
 
 </Warning>
 
 ## Capabilities
 
 Clients that support elicitation **MUST** declare the `elicitation` capability during
-[initialization](/specification/2025-06-18/basic/lifecycle#initialization):
+[initialization](../basic/lifecycle#initialization):
 
 ```json
 {
   "capabilities": {
-    "elicitation": {}
+    "elicitation": {
+      "form": {},
+      "url": {}
+    }
   }
 }
 ```
 
+For backwards compatibility, an empty capabilities object is equivalent to declaring support for `form` mode only:
+
+```jsonc
+{
+  "capabilities": {
+    "elicitation": {}, // Equivalent to { "form": {} }
+  },
+}
+```
+
+Clients declaring the `elicitation` capability **MUST** support at least one mode (`form` or `url`).
+
+Servers **MUST NOT** send elicitation requests with modes that are not supported by the client.
+
 ## Protocol Messages
 
-### Creating Elicitation Requests
+### Elicitation Requests
 
-To request information from a user, servers send an `elicitation/create` request:
+To request information from a user, servers send an `elicitation/create` request.
 
-#### Simple Text Request
+All elicitation requests **MUST** include the following parameters:
+
+| Name      | Type   | Options       | Description                                                                            |
+| --------- | ------ | ------------- | -------------------------------------------------------------------------------------- |
+| `mode`    | string | `form`, `url` | The mode of the elicitation. Optional for form mode (defaults to `"form"` if omitted). |
+| `message` | string |               | A human-readable message explaining why the interaction is needed.                     |
+
+The `mode` parameter specifies the type of elicitation:
+
+- `"form"`: In-band structured data collection with optional schema validation. Data is exposed to the client.
+- `"url"`: Out-of-band interaction via URL navigation. Data (other than the URL itself) is **not** exposed to the client.
+
+For backwards compatibility, servers **MAY** omit the `mode` field for form mode elicitation requests. Clients **MUST** treat requests without a `mode` field as form mode.
+
+### Form Mode Elicitation Requests
+
+Form mode elicitation allows servers to collect structured data directly through the MCP client.
+
+Form mode elicitation requests **MUST** either specify `mode: "form"` or omit the `mode` field, and include these additional parameters:
+
+| Name              | Type   | Description                                                    |
+| ----------------- | ------ | -------------------------------------------------------------- |
+| `requestedSchema` | object | A JSON Schema defining the structure of the expected response. |
+
+#### Requested Schema
+
+The `requestedSchema` parameter allows servers to define the structure of the expected
+response using a restricted subset of JSON Schema.
+
+To simplify client user experience, form mode elicitation schemas are limited to flat objects
+with primitive properties only.
+
+The schema is restricted to these primitive types:
+
+1. **String Schema**
+
+   ```json
+   {
+     "type": "string",
+     "title": "Display Name",
+     "description": "Description text",
+     "minLength": 3,
+     "maxLength": 50,
+     "pattern": "^[A-Za-z]+$",
+     "format": "email",
+     "default": "user@example.com"
+   }
+   ```
+
+   Supported formats: `email`, `uri`, `date`, `date-time`
+
+2. **Number Schema**
+
+   ```json
+   {
+     "type": "number", // or "integer"
+     "title": "Display Name",
+     "description": "Description text",
+     "minimum": 0,
+     "maximum": 100,
+     "default": 50
+   }
+   ```
+
+3. **Boolean Schema**
+
+   ```json
+   {
+     "type": "boolean",
+     "title": "Display Name",
+     "description": "Description text",
+     "default": false
+   }
+   ```
+
+4. **Enum Schema**
+
+   Single-select enum (without titles):
+
+   ```json
+   {
+     "type": "string",
+     "title": "Color Selection",
+     "description": "Choose your favorite color",
+     "enum": ["Red", "Green", "Blue"],
+     "default": "Red"
+   }
+   ```
+
+   Single-select enum (with titles):
+
+   ```json
+   {
+     "type": "string",
+     "title": "Color Selection",
+     "description": "Choose your favorite color",
+     "oneOf": [
+       { "const": "#FF0000", "title": "Red" },
+       { "const": "#00FF00", "title": "Green" },
+       { "const": "#0000FF", "title": "Blue" }
+     ],
+     "default": "#FF0000"
+   }
+   ```
+
+   Multi-select enum (without titles):
+
+   ```json
+   {
+     "type": "array",
+     "title": "Color Selection",
+     "description": "Choose your favorite colors",
+     "minItems": 1,
+     "maxItems": 2,
+     "items": {
+       "type": "string",
+       "enum": ["Red", "Green", "Blue"]
+     },
+     "default": ["Red", "Green"]
+   }
+   ```
+
+   Multi-select enum (with titles):
+
+   ```json
+   {
+     "type": "array",
+     "title": "Color Selection",
+     "description": "Choose your favorite colors",
+     "minItems": 1,
+     "maxItems": 2,
+     "items": {
+       "anyOf": [
+         { "const": "#FF0000", "title": "Red" },
+         { "const": "#00FF00", "title": "Green" },
+         { "const": "#0000FF", "title": "Blue" }
+       ]
+     },
+     "default": ["#FF0000", "#00FF00"]
+   }
+   ```
+
+Clients can use this schema to:
+
+1. Generate appropriate input forms
+2. Validate user input before sending
+3. Provide better guidance to users
+
+All primitive types support optional default values to provide sensible starting points. Clients that support defaults SHOULD pre-populate form fields with these values.
+
+Note that complex nested structures, arrays of objects (beyond enums), and other advanced JSON Schema features are intentionally not supported to simplify client user experience.
+
+#### Example: Simple Text Request
 
 **Request:**
 
@@ -70,6 +244,7 @@ To request information from a user, servers send an `elicitation/create` request
   "id": 1,
   "method": "elicitation/create",
   "params": {
+    "mode": "form",
     "message": "Please provide your GitHub username",
     "requestedSchema": {
       "type": "object",
@@ -99,7 +274,7 @@ To request information from a user, servers send an `elicitation/create` request
 }
 ```
 
-#### Structured Data Request
+#### Example: Structured Data Request
 
 **Request:**
 
@@ -109,6 +284,7 @@ To request information from a user, servers send an `elicitation/create` request
   "id": 2,
   "method": "elicitation/create",
   "params": {
+    "mode": "form",
     "message": "Please provide your contact information",
     "requestedSchema": {
       "type": "object",
@@ -151,31 +327,134 @@ To request information from a user, servers send an `elicitation/create` request
 }
 ```
 
-**Reject Response Example:**
+### URL Mode Elicitation Requests
+
+<Note>
+
+**New feature:** URL mode elicitation is introduced in the `2025-11-25` version of the MCP specification. Its design and implementation may change in future protocol revisions.
+
+</Note>
+
+URL mode elicitation enables servers to direct users to external URLs for out-of-band interactions that must not pass through the MCP client. This is essential for auth flows, payment processing, and other sensitive or secure operations.
+
+URL mode elicitation requests **MUST** specify `mode: "url"`, a `message`, and include these additional parameters:
+
+| Name            | Type   | Description                               |
+| --------------- | ------ | ----------------------------------------- |
+| `url`           | string | The URL that the user should navigate to. |
+| `elicitationId` | string | A unique identifier for the elicitation.  |
+
+The `url` parameter **MUST** contain a valid URL.
+
+<Note>
+  **Important**: URL mode elicitation is *not* for authorizing the MCP client's
+  access to the MCP server (that's handled by [MCP
+  authorization](../basic/authorization)). Instead, it's used when the MCP
+  server needs to obtain sensitive information or third-party authorization on
+  behalf of the user. The MCP client's bearer token remains unchanged. The
+  client's only responsibility is to provide the user with context about the
+  elicitation URL the server wants them to open.
+</Note>
+
+#### Example: Request Sensitive Data
+
+This example shows a URL mode elicitation request directing the user to a secure URL where they can provide sensitive information (an API key, for example).
+The same request could direct the user into an OAuth authorization flow, or a payment flow. The only difference is the URL and the message.
+
+**Request:**
 
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 2,
-  "result": {
-    "action": "decline"
+  "id": 3,
+  "method": "elicitation/create",
+  "params": {
+    "mode": "url",
+    "elicitationId": "550e8400-e29b-41d4-a716-446655440000",
+    "url": "https://mcp.example.com/ui/set_api_key",
+    "message": "Please provide your API key to continue."
   }
 }
 ```
 
-**Cancel Response Example:**
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "action": "accept"
+  }
+}
+```
+
+The response with `action: "accept"` indicates that the user has consented to the
+interaction. It does not mean that the interaction is complete. The interaction occurs out
+of band and the client is not aware of the outcome until and unless the server sends a notification indicating completion.
+
+### Completion Notifications for URL Mode Elicitation
+
+Servers **MAY** send a `notifications/elicitation/complete` notification when an
+out-of-band interaction started by URL mode elicitation is completed. This allows clients to react programmatically if appropriate.
+
+Servers sending notifications:
+
+- **MUST** only send the notification to the client that initiated the elicitation request.
+- **MUST** include the `elicitationId` established in the original `elicitation/create` request.
+
+Clients:
+
+- **MUST** ignore notifications referencing unknown or already-completed IDs.
+- **MAY** wait for this notification to automatically retry requests that received a [URLElicitationRequiredError](#error-handling), update the user interface, or otherwise continue an interaction.
+- **SHOULD** still provide manual controls that let the user retry or cancel the original request (or otherwise resume interacting with the client) if the notification never arrives.
+
+#### Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/elicitation/complete",
+  "params": {
+    "elicitationId": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+### URL Elicitation Required Error
+
+When a request cannot be processed until an elicitation is completed, the server **MAY** return a [`URLElicitationRequiredError`](#error-handling) (code `-32042`) to indicate to the client that a URL mode elicitation is required. The server **MUST NOT** return this error except when URL mode elicitation is required.
+
+The error **MUST** include a list of elicitations that are required to complete before the original can be retried.
+
+Any elicitations returned in the error **MUST** be URL mode elicitations and have an `elicitationId` property.
+
+**Error Response:**
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": 2,
-  "result": {
-    "action": "cancel"
+  "error": {
+    "code": -32042, // URL_ELICITATION_REQUIRED
+    "message": "This request requires more information.",
+    "data": {
+      "elicitations": [
+        {
+          "mode": "url",
+          "elicitationId": "550e8400-e29b-41d4-a716-446655440000",
+          "url": "https://mcp.example.com/connect?elicitationId=550e8400-e29b-41d4-a716-446655440000",
+          "message": "Authorization is required to access your Example Co files."
+        }
+      ]
+    }
   }
 }
 ```
 
 ## Message Flow
+
+### Form Mode Flow
 
 ```mermaid
 sequenceDiagram
@@ -183,106 +462,74 @@ sequenceDiagram
     participant Client
     participant Server
 
-    Note over Server,Client: Server initiates elicitation
-    Server->>Client: elicitation/create
+    Note over Server: Server initiates elicitation
+    Server->>Client: elicitation/create (mode: form)
 
-    Note over Client,User: Human interaction
-    Client->>User: Present elicitation UI
+    Note over User,Client: Present elicitation UI
     User-->>Client: Provide requested information
 
     Note over Server,Client: Complete request
-    Client-->>Server: Return user response
+    Client->>Server: Return user response
 
     Note over Server: Continue processing with new information
 ```
 
-## Request Schema
+### URL Mode Flow
 
-The `requestedSchema` field allows servers to define the structure of the expected response using a restricted subset of JSON Schema. To simplify implementation for clients, elicitation schemas are limited to flat objects with primitive properties only:
+```mermaid
+sequenceDiagram
+    participant UserAgent as User Agent (Browser)
+    participant User
+    participant Client
+    participant Server
 
-```json
-"requestedSchema": {
-  "type": "object",
-  "properties": {
-    "propertyName": {
-      "type": "string",
-      "title": "Display Name",
-      "description": "Description of the property"
-    },
-    "anotherProperty": {
-      "type": "number",
-      "minimum": 0,
-      "maximum": 100
-    }
-  },
-  "required": ["propertyName"]
-}
+    Note over Server: Server initiates elicitation
+    Server->>Client: elicitation/create (mode: url)
+
+    Client->>User: Present consent to open URL
+    User-->>Client: Provide consent
+
+    Client->>UserAgent: Open URL
+    Client->>Server: Accept response
+
+    Note over User,UserAgent: User interaction
+    UserAgent-->>Server: Interaction complete
+    Server-->>Client: notifications/elicitation/complete (optional)
+
+    Note over Server: Continue processing with new information
 ```
 
-### Supported Schema Types
+### URL Mode With Elicitation Required Error Flow
 
-The schema is restricted to these primitive types:
+```mermaid
+sequenceDiagram
+    participant UserAgent as User Agent (Browser)
+    participant User
+    participant Client
+    participant Server
 
-1. **String Schema**
+    Client->>Server: tools/call
 
-   ```json
-   {
-     "type": "string",
-     "title": "Display Name",
-     "description": "Description text",
-     "minLength": 3,
-     "maxLength": 50,
-     "format": "email" // Supported: "email", "uri", "date", "date-time"
-   }
-   ```
+    Note over Server: Server needs authorization
+    Server->>Client: URLElicitationRequiredError
+    Note over Client: Client notes the original request can be retried after elicitation
 
-   Supported formats: `email`, `uri`, `date`, `date-time`
+    Client->>User: Present consent to open URL
+    User-->>Client: Provide consent
 
-2. **Number Schema**
+    Client->>UserAgent: Open URL
 
-   ```json
-   {
-     "type": "number", // or "integer"
-     "title": "Display Name",
-     "description": "Description text",
-     "minimum": 0,
-     "maximum": 100
-   }
-   ```
+    Note over User,UserAgent: User interaction
 
-3. **Boolean Schema**
+    UserAgent-->>Server: Interaction complete
+    Server-->>Client: notifications/elicitation/complete (optional)
 
-   ```json
-   {
-     "type": "boolean",
-     "title": "Display Name",
-     "description": "Description text",
-     "default": false
-   }
-   ```
-
-4. **Enum Schema**
-   ```json
-   {
-     "type": "string",
-     "title": "Display Name",
-     "description": "Description text",
-     "enum": ["option1", "option2", "option3"],
-     "enumNames": ["Option 1", "Option 2", "Option 3"]
-   }
-   ```
-
-Clients can use this schema to:
-
-1. Generate appropriate input forms
-2. Validate user input before sending
-3. Provide better guidance to users
-
-Note that complex nested structures, arrays of objects, and other advanced JSON Schema features are intentionally not supported to simplify client implementation.
+    Client->>Server: Retry tools/call (optional)
+```
 
 ## Response Actions
 
-Elicitation responses use a three-action model to clearly distinguish between different user actions:
+Elicitation responses use a three-action model to clearly distinguish between different user actions. These actions apply to both form and URL elicitation modes.
 
 ```json
 {
@@ -301,18 +548,17 @@ Elicitation responses use a three-action model to clearly distinguish between di
 The three response actions are:
 
 1. **Accept** (`action: "accept"`): User explicitly approved and submitted with data
-
-   - The `content` field contains the submitted data matching the requested schema
+   - For form mode: The `content` field contains the submitted data matching the requested schema
+   - For URL mode: The `content` field is omitted
    - Example: User clicked "Submit", "OK", "Confirm", etc.
 
 2. **Decline** (`action: "decline"`): User explicitly declined the request
-
    - The `content` field is typically omitted
    - Example: User clicked "Reject", "Decline", "No", etc.
 
 3. **Cancel** (`action: "cancel"`): User dismissed without making an explicit choice
    - The `content` field is typically omitted
-   - Example: User closed the dialog, clicked outside, pressed Escape, etc.
+   - Example: User closed the dialog, clicked outside, pressed Escape, browser failed to load, etc.
 
 Servers should handle each state appropriately:
 
@@ -320,12 +566,216 @@ Servers should handle each state appropriately:
 - **Decline**: Handle explicit decline (e.g., offer alternatives)
 - **Cancel**: Handle dismissal (e.g., prompt again later)
 
+## Implementation Considerations
+
+### Statefulness
+
+Most practical uses of elicitation require that the server maintain state about users:
+
+- Whether required information has been collected (e.g., the user's display name via form mode elicitation)
+- Status of resource access (e.g., API keys or a payment flow via URL mode elicitation)
+
+Servers implementing elicitation **MUST** securely associate this state with individual users following the guidelines in the [security best practices](../basic/security_best_practices) document. Specifically:
+
+- State **MUST NOT** be associated with session IDs alone
+- State storage **MUST** be protected against unauthorized access
+- For remote MCP servers, user identification **MUST** be derived from credentials acquired via [MCP authorization](../basic/authorization) when possible (e.g. `sub` claim)
+
+<Note>
+  The examples in this section are non-normative and illustrate potential uses
+  of elicitation. Implementers should adapt these patterns to their specific
+  requirements while maintaining security best practices.
+</Note>
+
+### URL Mode Elicitation for Sensitive Data
+
+For servers that interact with external APIs requiring sensitive information (e.g., credentials, payment information), URL mode elicitation provides a secure mechanism for users to provide this information without exposing it to the MCP client.
+
+In this pattern:
+
+1. The server directs users to a secure web page (served over HTTPS)
+2. The page presents a branded form UI on a domain the user trusts
+3. Users enter sensitive credentials directly into the secure form
+4. The server stores credentials securely, bound to the user's identity
+5. Subsequent MCP requests use these stored credentials for API access
+
+This approach ensures that sensitive credentials never pass through the LLM context, MCP client or any intermediate MCP servers, reducing the risk of exposure through client-side logging or other attack vectors.
+
+### URL Mode Elicitation for OAuth Flows
+
+URL mode elicitation enables a pattern where MCP servers act as OAuth clients to third-party resource servers.
+Authorization with external APIs enabled by URL mode elicitation is separate from [MCP authorization](../basic/authorization). MCP servers **MUST NOT** rely on URL mode elicitation to authorize users for themselves.
+
+#### Understanding the Distinction
+
+- **MCP Authorization**: Required OAuth flow between the MCP client and MCP server (covered in the [authorization specification](../basic/authorization))
+- **External (third-party) Authorization**: Optional authorization between the MCP server and a third-party resource server, initiated via URL mode elicitation
+
+In external authorization, the server acts as both:
+
+- An OAuth resource server (to the MCP client)
+- An OAuth client (to the third-party resource server)
+
+Example scenario:
+
+- An MCP client connects to an MCP server
+- The MCP server integrates with various different third-party services
+- When the MCP client calls a tool that requires access to a third-party service, the MCP server needs credentials for that service
+
+The critical security requirements are:
+
+1. **The third-party credentials MUST NOT transit through the MCP client**: The client must never see third-party credentials to protect the security boundary
+2. **The MCP server MUST NOT use the client's credentials for the third-party service**: That would be [token passthrough](../basic/security_best_practices#token-passthrough), which is forbidden
+3. **The user MUST authorize the MCP server directly**: The interaction happens outside the MCP protocol, without involving the MCP client
+4. **The MCP server is responsible for tokens**: The MCP server is responsible for storing and managing the third-party tokens obtained through the URL mode elicitation (in other words, the MCP server must be stateful).
+
+Credentials obtained via URL mode elicitation are distinct from the MCP server credentials used by the MCP client. The MCP server **MUST NOT** transmit credentials obtained through URL mode elicitation to the MCP client.
+
+<Note>
+  For additional background, refer to the [token passthrough
+  section](../basic/security_best_practices#token-passthrough) of the Security
+  Best Practices document to understand why MCP servers cannot act as
+  pass-through proxies.
+</Note>
+
+#### Implementation Pattern
+
+When implementing external authorization via URL mode elicitation:
+
+1. The MCP server generates an authorization URL, acting as an OAuth client to the third-party service
+2. The MCP server stores internal state that associates (binds) the elicitation request with the user's identity.
+3. The MCP server sends a URL mode elicitation request to the client with a URL that can start the authorization flow.
+4. The user completes the OAuth flow directly with the third-party authorization server
+5. The third-party authorization server redirects back to the MCP server
+6. The MCP server securely stores the third-party tokens, bound to the user's identity
+7. Future MCP requests can leverage these stored tokens for API access to the third-party resource server
+
+The following is a non-normative example of how this pattern could be implemented:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant UserAgent as User Agent (Browser)
+    participant 3AS as 3rd Party AS
+    participant 3RS as 3rd Party RS
+    participant Client as MCP Client
+    participant Server as MCP Server
+
+    Client->>Server: tools/call
+    Note over Server: Needs 3rd-party authorization for user
+    Note over Server: Store state (bind the elicitation request to the user)
+    Server->>Client: URLElicitationRequiredError<br> (mode: "url", url: "https://mcp.example.com/connect?...")
+    Note over Client: Client notes the tools/call request can be retried later
+    Client->>User: Present consent to open URL
+    User->>Client: Provide consent
+    Client->>UserAgent: Open URL
+    Client->>Server: Accept response
+    UserAgent->>Server: Load connect route
+    Note over Server: Confirm: user is logged into MCP Server or MCP AS<br>Confirm: elicitation user matches session user
+    Server->>UserAgent: Redirect to third-party authorization endpoint
+    UserAgent->>3AS: Load authorize route
+    Note over 3AS,User: User interaction (OAuth flow):<br>User consents to scoped MCP Server access
+    3AS->>UserAgent: redirect to MCP Server's redirect_uri
+    UserAgent->>Server: load redirect_uri page
+    Note over Server: Confirm: redirect_uri belongs to MCP Server
+    Server->>3AS: Exchange authorization code for  OAuth tokens
+    3AS->>Server: Grants tokens
+    Note over Server: Bind tokens to MCP user identity
+    Server-->>Client: notifications/elicitation/complete (optional)
+    Client->>Server: Retry tools/call
+    Note over Server: Retrieve token bound to user identity
+    Server->>3RS: Call 3rd-party API
+```
+
+This pattern maintains clear security boundaries while enabling rich integrations with third-party services that require user authorization.
+
+## Error Handling
+
+Servers **MUST** return standard JSON-RPC errors for common failure cases:
+
+- When a request cannot be processed until an elicitation is completed: `-32042` (`URLElicitationRequiredError`)
+
+Clients **MUST** return standard JSON-RPC errors for common failure cases:
+
+- Server sends an `elicitation/create` request with a mode not declared in client capabilities: `-32602` (Invalid params)
+
 ## Security Considerations
 
-1. Servers **MUST NOT** request sensitive information through elicitation
-2. Clients **SHOULD** implement user approval controls
-3. Both parties **SHOULD** validate elicitation content against the provided schema
-4. Clients **SHOULD** provide clear indication of which server is requesting information
-5. Clients **SHOULD** allow users to decline elicitation requests at any time
-6. Clients **SHOULD** implement rate limiting
-7. Clients **SHOULD** present elicitation requests in a way that makes it clear what information is being requested and why
+1. Servers **MUST** bind elicitation requests to the client and user identity
+1. Clients **MUST** provide clear indication of which server is requesting information
+1. Clients **SHOULD** implement user approval controls
+1. Clients **SHOULD** allow users to decline elicitation requests at any time
+1. Clients **SHOULD** implement rate limiting
+1. Clients **SHOULD** present elicitation requests in a way that makes it clear what information is being requested and why
+
+### Safe URL Handling
+
+MCP servers requesting elicitation:
+
+1. **MUST NOT** include sensitive information about the end-user, including credentials, personal identifiable information, etc., in the URL sent to the client in a URL elicitation request.
+2. **MUST NOT** provide a URL which is pre-authenticated to access a protected resource, as the URL could be used to impersonate the user by a malicious client.
+3. **SHOULD NOT** include URLs intended to be clickable in any field of a form mode elicitation request.
+4. **SHOULD** use HTTPS URLs for non-development environments.
+
+These server requirements ensure that client implementations have clear rules about when to present a URL to the user, so that the client-side rules (below) can be consistently applied.
+
+Clients implementing URL mode elicitation **MUST** handle URLs carefully to prevent users from unknowingly clicking malicious links.
+
+When handling URL mode elicitation requests, MCP clients:
+
+1. **MUST NOT** automatically pre-fetch the URL or any of its metadata.
+2. **MUST NOT** open the URL without explicit consent from the user.
+3. **MUST** show the full URL to the user for examination before consent.
+4. **MUST** open the URL provided by the server in a secure manner that does not enable the client or LLM to inspect the content or user inputs.
+   For example, on iOS, [SFSafariViewController](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller) is good, but [WkWebView](https://developer.apple.com/documentation/webkit/wkwebview) is not.
+5. **SHOULD** highlight the domain of the URL to mitigate subdomain spoofing.
+6. **SHOULD** have warnings for ambiguous/suspicious URIs (i.e., containing Punycode).
+7. **SHOULD NOT** render URLs as clickable in any field of an elicitation request, except for the `url` field in a URL elicitation request (with the restrictions detailed above).
+
+### Identifying the User
+
+Servers **MUST NOT** rely on client-provided user identification without server verification, as this can be forged.
+Instead, servers **SHOULD** follow [security best practices](../basic/security_best_practices).
+
+Non-normative examples:
+
+- Incorrect: Treat user input like "I am joe@example.com" as authoritative
+- Correct: Rely on [authorization](../basic/authorization) to identify the user
+
+### Form Mode Security
+
+1. Servers **MUST NOT** request sensitive information (passwords, API keys, etc.) via form mode
+2. Clients **SHOULD** validate all responses against the provided schema
+3. Servers **SHOULD** validate received data matches the requested schema
+
+#### Phishing
+
+URL mode elicitation returns a URL that an attacker can use to send to a victim. The MCP Server **MUST** verify the identity of the user who opens the URL before accepting information.
+
+Typically identity verification is done by leveraging the [MCP authorization server](../basic/authorization) to identify the user, through a session cookie or equivalent in the browser.
+
+For example, URL mode elicitation may be used to perform OAuth flows where the server acts as an OAuth client of another resource server. Without proper mitigation, the following phishing attack is possible:
+
+1. A malicious user (Alice) connected to a benign server triggers an elicitation request
+2. The benign server generates an authorization URL, acting as an OAuth client of a third-party authorization server
+3. Alice's client displays the URL and asks for consent
+4. Instead of clicking on the link, Alice tricks a victim user (Bob) of the same benign server into clicking it
+5. Bob opens the link and completes the authorization, thinking they are authorizing their own connection to the benign server
+6. The benign server receives a callback/redirect form the third-party authorization server, and assumes it's Alice's request
+7. The tokens for the third-party server are bound to Alice's session and identity, instead of Bob's, resulting in an account takeover
+
+To prevent this attack, the server **MUST** ensure that the user who started the elicitation request (the end-user who is accessing the server via the MCP client) is the same user who completes the authorization flow.
+
+There are many ways to achieve this and the best way will depend on the specific implementation.
+
+As a common, non-normative example, consider a case where the MCP server is accessible via the web and desires to perform a third-party authorization code flow.
+To prevent the phishing attack, the server would create a URL mode elicitation to `https://mcp.example.com/connect?elicitationId=...` rather than the third-party authorization endpoint.
+This "connect URL" must ensure the user who opened the page is the same user who the elicitation was generated for.
+It would, for example, check that the user has a valid session cookie and that the session cookie is for the same user who was using the MCP client to generate the URL mode elicitation.
+This could be done by comparing the authoritative subject (`sub` claim) from the MCP server's authorization server to the subject from the session cookie.
+Once that page ensures the same user, it can send the user to the third-party authorization server at `https://example.com/authorize?...` where a normal OAuth flow can be completed.
+
+In other cases, the server may not be accessible via the web and may not be able to use a session cookie to identify the user.
+In this case, the server must use a different mechanism to identify the user who opens the elicitation URL is the same user who the elicitation was generated for.
+
+In all implementations, the server **MUST** ensure that the mechanism to determine the user's identity is resilient to attacks where an attacker can modify the elicitation URL.

--- a/spec/lifecycle.md
+++ b/spec/lifecycle.md
@@ -4,8 +4,6 @@ title: Lifecycle
 
 <div id="enable-section-numbers" />
 
-<Info>**Protocol Revision**: 2025-06-18</Info>
-
 The Model Context Protocol (MCP) defines a rigorous lifecycle for client-server
 connections that ensures proper capability negotiation and state management.
 
@@ -58,18 +56,40 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
   "id": 1,
   "method": "initialize",
   "params": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-11-25",
     "capabilities": {
       "roots": {
         "listChanged": true
       },
       "sampling": {},
-      "elicitation": {}
+      "elicitation": {
+        "form": {},
+        "url": {}
+      },
+      "tasks": {
+        "requests": {
+          "elicitation": {
+            "create": {}
+          },
+          "sampling": {
+            "createMessage": {}
+          }
+        }
+      }
     },
     "clientInfo": {
       "name": "ExampleClient",
       "title": "Example Client Display Name",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "description": "An example MCP client application",
+      "icons": [
+        {
+          "src": "https://example.com/icon.png",
+          "mimeType": "image/png",
+          "sizes": ["48x48"]
+        }
+      ],
+      "websiteUrl": "https://example.com"
     }
   }
 }
@@ -82,7 +102,7 @@ The server **MUST** respond with its own capabilities and information:
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-11-25",
     "capabilities": {
       "logging": {},
       "prompts": {
@@ -94,12 +114,30 @@ The server **MUST** respond with its own capabilities and information:
       },
       "tools": {
         "listChanged": true
+      },
+      "tasks": {
+        "list": {},
+        "cancel": {},
+        "requests": {
+          "tools": {
+            "call": {}
+          }
+        }
       }
     },
     "serverInfo": {
       "name": "ExampleServer",
       "title": "Example Server Display Name",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "description": "An example MCP server providing tools and resources",
+      "icons": [
+        {
+          "src": "https://example.com/server-icon.svg",
+          "mimeType": "image/svg+xml",
+          "sizes": ["any"]
+        }
+      ],
+      "websiteUrl": "https://example.com/server"
     },
     "instructions": "Optional instructions for the client"
   }
@@ -117,11 +155,11 @@ to indicate it is ready to begin normal operations:
 ```
 
 - The client **SHOULD NOT** send requests other than
-  [pings](/specification/2025-06-18/basic/utilities/ping) before the server has responded to the
+  [pings](/specification/2025-11-25/basic/utilities/ping) before the server has responded to the
   `initialize` request.
 - The server **SHOULD NOT** send requests other than
-  [pings](/specification/2025-06-18/basic/utilities/ping) and
-  [logging](/specification/2025-06-18/server/utilities/logging) before receiving the `initialized`
+  [pings](/specification/2025-11-25/basic/utilities/ping) and
+  [logging](/specification/2025-11-25/server/utilities/logging) before receiving the `initialized`
   notification.
 
 #### Version Negotiation
@@ -140,7 +178,7 @@ disconnect.
 If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
 <protocol-version>` HTTP header on all subsequent requests to the MCP
 server.
-For details, see [the Protocol Version Header section in Transports](/specification/2025-06-18/basic/transports#protocol-version-header).
+For details, see [the Protocol Version Header section in Transports](/specification/2025-11-25/basic/transports#protocol-version-header).
 </Note>
 
 #### Capability Negotiation
@@ -150,18 +188,20 @@ available during the session.
 
 Key capabilities include:
 
-| Category | Capability     | Description                                                                               |
-| -------- | -------------- | ----------------------------------------------------------------------------------------- |
-| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2025-06-18/client/roots)             |
-| Client   | `sampling`     | Support for LLM [sampling](/specification/2025-06-18/client/sampling) requests            |
-| Client   | `elicitation`  | Support for server [elicitation](/specification/2025-06-18/client/elicitation) requests   |
-| Client   | `experimental` | Describes support for non-standard experimental features                                  |
-| Server   | `prompts`      | Offers [prompt templates](/specification/2025-06-18/server/prompts)                       |
-| Server   | `resources`    | Provides readable [resources](/specification/2025-06-18/server/resources)                 |
-| Server   | `tools`        | Exposes callable [tools](/specification/2025-06-18/server/tools)                          |
-| Server   | `logging`      | Emits structured [log messages](/specification/2025-06-18/server/utilities/logging)       |
-| Server   | `completions`  | Supports argument [autocompletion](/specification/2025-06-18/server/utilities/completion) |
-| Server   | `experimental` | Describes support for non-standard experimental features                                  |
+| Category | Capability     | Description                                                                                   |
+| -------- | -------------- | --------------------------------------------------------------------------------------------- |
+| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2025-11-25/client/roots)                 |
+| Client   | `sampling`     | Support for LLM [sampling](/specification/2025-11-25/client/sampling) requests                |
+| Client   | `elicitation`  | Support for server [elicitation](/specification/2025-11-25/client/elicitation) requests       |
+| Client   | `tasks`        | Support for [task-augmented](/specification/2025-11-25/basic/utilities/tasks) client requests |
+| Client   | `experimental` | Describes support for non-standard experimental features                                      |
+| Server   | `prompts`      | Offers [prompt templates](/specification/2025-11-25/server/prompts)                           |
+| Server   | `resources`    | Provides readable [resources](/specification/2025-11-25/server/resources)                     |
+| Server   | `tools`        | Exposes callable [tools](/specification/2025-11-25/server/tools)                              |
+| Server   | `logging`      | Emits structured [log messages](/specification/2025-11-25/server/utilities/logging)           |
+| Server   | `completions`  | Supports argument [autocompletion](/specification/2025-11-25/server/utilities/completion)     |
+| Server   | `tasks`        | Support for [task-augmented](/specification/2025-11-25/basic/utilities/tasks) server requests |
+| Server   | `experimental` | Describes support for non-standard experimental features                                      |
 
 Capability objects can describe sub-capabilities like:
 
@@ -187,7 +227,7 @@ mechanism should be used to signal connection termination:
 
 #### stdio
 
-For the stdio [transport](/specification/2025-06-18/basic/transports), the client **SHOULD** initiate
+For the stdio [transport](/specification/2025-11-25/basic/transports), the client **SHOULD** initiate
 shutdown by:
 
 1. First, closing the input stream to the child process (the server)
@@ -200,7 +240,7 @@ exiting.
 
 #### HTTP
 
-For HTTP [transports](/specification/2025-06-18/basic/transports), shutdown is indicated by closing the
+For HTTP [transports](/specification/2025-11-25/basic/transports), shutdown is indicated by closing the
 associated HTTP connection(s).
 
 ## Timeouts
@@ -208,14 +248,14 @@ associated HTTP connection(s).
 Implementations **SHOULD** establish timeouts for all sent requests, to prevent hung
 connections and resource exhaustion. When the request has not received a success or error
 response within the timeout period, the sender **SHOULD** issue a [cancellation
-notification](/specification/2025-06-18/basic/utilities/cancellation) for that request and stop waiting for
+notification](/specification/2025-11-25/basic/utilities/cancellation) for that request and stop waiting for
 a response.
 
 SDKs and other middleware **SHOULD** allow these timeouts to be configured on a
 per-request basis.
 
 Implementations **MAY** choose to reset the timeout clock when receiving a [progress
-notification](/specification/2025-06-18/basic/utilities/progress) corresponding to the request, as this
+notification](/specification/2025-11-25/basic/utilities/progress) corresponding to the request, as this
 implies that work is actually happening. However, implementations **SHOULD** always
 enforce a maximum timeout, regardless of progress notifications, to limit the impact of a
 misbehaving client or server.

--- a/spec/ping.md
+++ b/spec/ping.md
@@ -4,8 +4,6 @@ title: Ping
 
 <div id="enable-section-numbers" />
 
-<Info>**Protocol Revision**: 2025-06-18</Info>
-
 The Model Context Protocol includes an optional ping mechanism that allows either party
 to verify that their counterpart is still responsive and the connection is alive.
 

--- a/spec/progress.md
+++ b/spec/progress.md
@@ -4,8 +4,6 @@ title: Progress
 
 <div id="enable-section-numbers" />
 
-<Info>**Protocol Revision**: 2025-06-18</Info>
-
 The Model Context Protocol (MCP) supports optional progress tracking for long-running
 operations through notification messages. Either side can send progress notifications to
 provide updates about operation status.
@@ -60,7 +58,6 @@ The receiver **MAY** then send progress notifications containing:
 ## Behavior Requirements
 
 1. Progress notifications **MUST** only reference tokens that:
-
    - Were provided in an active request
    - Are associated with an in-progress operation
 
@@ -68,6 +65,10 @@ The receiver **MAY** then send progress notifications containing:
    - Choose not to send any progress notifications
    - Send notifications at whatever frequency they deem appropriate
    - Omit the total value if unknown
+
+3. For [task-augmented requests](./tasks), the `progressToken` provided in the original request **MUST** continue to be used for progress notifications throughout the task's lifetime, even after the `CreateTaskResult` has been returned. The progress token remains valid and associated with the task until the task reaches a terminal status.
+   - Progress notifications for tasks **MUST** use the same `progressToken` that was provided in the initial task-augmented request
+   - Progress notifications for tasks **MUST** stop after the task reaches a terminal status (`completed`, `failed`, or `cancelled`)
 
 ```mermaid
 sequenceDiagram

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -1,0 +1,900 @@
+---
+title: Tasks
+---
+
+<div id="enable-section-numbers" />
+
+<Note>
+
+Tasks were introduced in version 2025-11-25 of the MCP specification and are currently considered **experimental**.
+The design and behavior of tasks may evolve in future protocol versions.
+
+</Note>
+
+The Model Context Protocol (MCP) allows requestors — which can be either clients or servers, depending on the direction of communication — to augment their requests with **tasks**. Tasks are durable state machines that carry information about the underlying execution state of the request they wrap, and are intended for requestor polling and deferred result retrieval. Each task is uniquely identifiable by a receiver-generated **task ID**.
+
+Tasks are useful for representing expensive computations and batch processing requests, and integrate seamlessly with external job APIs.
+
+## Definitions
+
+Tasks represent parties as either "requestors" or "receivers," defined as follows:
+
+- **Requestor:** The sender of a task-augmented request. This can be the client or the server — either can create tasks.
+- **Receiver:** The receiver of a task-augmented request, and the entity executing the task. This can be the client or the server — either can receive and execute tasks.
+
+## User Interaction Model
+
+Tasks are designed to be **requestor-driven** - requestors are responsible for augmenting requests with tasks and for polling for the results of those tasks; meanwhile, receivers tightly control which requests (if any) support task-based execution and manages the lifecycles of those tasks.
+
+This requestor-driven approach ensures deterministic response handling and enables sophisticated patterns such as dispatching concurrent requests, which only the requestor has sufficient context to orchestrate.
+
+Implementations are free to expose tasks through any interface pattern that suits their needs — the protocol itself does not mandate any specific user interaction model.
+
+## Capabilities
+
+Servers and clients that support task-augmented requests **MUST** declare a `tasks` capability during initialization. The `tasks` capability is structured by request category, with boolean properties indicating which specific request types support task augmentation.
+
+### Server Capabilities
+
+Servers declare if they support tasks, and if so, which server-side requests can be augmented with tasks.
+
+| Capability                  | Description                                          |
+| --------------------------- | ---------------------------------------------------- |
+| `tasks.list`                | Server supports the `tasks/list` operation           |
+| `tasks.cancel`              | Server supports the `tasks/cancel` operation         |
+| `tasks.requests.tools.call` | Server supports task-augmented `tools/call` requests |
+
+```json
+{
+  "capabilities": {
+    "tasks": {
+      "list": {},
+      "cancel": {},
+      "requests": {
+        "tools": {
+          "call": {}
+        }
+      }
+    }
+  }
+}
+```
+
+### Client Capabilities
+
+Clients declare if they support tasks, and if so, which client-side requests can be augmented with tasks.
+
+| Capability                              | Description                                                      |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| `tasks.list`                            | Client supports the `tasks/list` operation                       |
+| `tasks.cancel`                          | Client supports the `tasks/cancel` operation                     |
+| `tasks.requests.sampling.createMessage` | Client supports task-augmented `sampling/createMessage` requests |
+| `tasks.requests.elicitation.create`     | Client supports task-augmented `elicitation/create` requests     |
+
+```json
+{
+  "capabilities": {
+    "tasks": {
+      "list": {},
+      "cancel": {},
+      "requests": {
+        "sampling": {
+          "createMessage": {}
+        },
+        "elicitation": {
+          "create": {}
+        }
+      }
+    }
+  }
+}
+```
+
+### Capability Negotiation
+
+During the initialization phase, both parties exchange their `tasks` capabilities to establish which operations support task-based execution. Requestors **SHOULD** only augment requests with a task if the corresponding capability has been declared by the receiver.
+
+For example, if a server's capabilities include `tasks.requests.tools.call: {}`, then clients may augment `tools/call` requests with a task. If a client's capabilities include `tasks.requests.sampling.createMessage: {}`, then servers may augment `sampling/createMessage` requests with a task.
+
+If `capabilities.tasks` is not defined, the peer **SHOULD NOT** attempt to create tasks during requests.
+
+The set of capabilities in `capabilities.tasks.requests` is exhaustive. If a request type is not present, it does not support task-augmentation.
+
+`capabilities.tasks.list` controls if the `tasks/list` operation is supported by the party.
+
+`capabilities.tasks.cancel` controls if the `tasks/cancel` operation is supported by the party.
+
+### Tool-Level Negotiation
+
+Tool calls are given special consideration for the purpose of task augmentation. In the result of `tools/list`, tools declare support for tasks via `execution.taskSupport`, which if present can have a value of `"required"`, `"optional"`, or `"forbidden"`.
+
+This is to be interpreted as a fine-grained layer in addition to capabilities, following these rules:
+
+1. If a server's capabilities do not include `tasks.requests.tools.call`, then clients **MUST NOT** attempt to use task augmentation on that server's tools, regardless of the `execution.taskSupport` value.
+1. If a server's capabilities include `tasks.requests.tools.call`, then clients consider the value of `execution.taskSupport`, and handle it accordingly:
+   1. If `execution.taskSupport` is not present or `"forbidden"`, clients **MUST NOT** attempt to invoke the tool as a task. Servers **SHOULD** return a `-32601` (Method not found) error if a client attempts to do so. This is the default behavior.
+   1. If `execution.taskSupport` is `"optional"`, clients **MAY** invoke the tool as a task or as a normal request.
+   1. If `execution.taskSupport` is `"required"`, clients **MUST** invoke the tool as a task. Servers **MUST** return a `-32601` (Method not found) error if a client does not attempt to do so.
+
+## Protocol Messages
+
+### Creating Tasks
+
+Task-augmented requests follow a two-phase response pattern that differs from normal requests:
+
+- **Normal requests**: The server processes the request and returns the actual operation result directly.
+- **Task-augmented requests**: The server accepts the request and immediately returns a `CreateTaskResult` containing task data. The actual operation result becomes available later through `tasks/result` after the task completes.
+
+To create a task, requestors send a request with the `task` field included in the request params. Requestors **MAY** include a `ttl` value indicating the desired task lifetime duration (in milliseconds) since its creation.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "city": "New York"
+    },
+    "task": {
+      "ttl": 60000
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "task": {
+      "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+      "status": "working",
+      "statusMessage": "The operation is now in progress.",
+      "createdAt": "2025-11-25T10:30:00Z",
+      "lastUpdatedAt": "2025-11-25T10:40:00Z",
+      "ttl": 60000,
+      "pollInterval": 5000
+    }
+  }
+}
+```
+
+When a receiver accepts a task-augmented request, it returns a [`CreateTaskResult`](/specification/2025-11-25/schema#createtaskresult) containing task data. The response does not include the actual operation result. The actual result (e.g., tool result for `tools/call`) becomes available only through `tasks/result` after the task completes.
+
+<Note>
+
+When a task is created in response to a `tools/call` request, host applications may wish to return control to the model while the task is executing. This allows the model to continue processing other requests or perform additional work while waiting for the task to complete.
+
+To support this pattern, servers can provide an optional `io.modelcontextprotocol/model-immediate-response` key in the `_meta` field of the `CreateTaskResult`. The value of this key should be a string intended to be passed as an immediate tool result to the model.
+If a server does not provide this field, the host application can fall back to its own predefined message.
+
+This guidance is non-binding and is provisional logic intended to account for the specific use case. This behavior may be formalized or modified as part of `CreateTaskResult` in future protocol versions.
+
+</Note>
+
+### Getting Tasks
+
+<Note>
+
+In the Streamable HTTP (SSE) transport, clients **MAY** disconnect from an SSE stream opened by the server in response to a `tasks/get` request at any time.
+
+While this note is not prescriptive regarding the specific usage of SSE streams, all implementations **MUST** continue to comply with the existing [Streamable HTTP transport specification](../transports#sending-messages-to-the-server).
+
+</Note>
+
+Requestors poll for task completion by sending [`tasks/get`](/specification/2025-11-25/schema#tasks%2Fget) requests.
+Requestors **SHOULD** respect the `pollInterval` provided in responses when determining polling frequency.
+
+Requestors **SHOULD** continue polling until the task reaches a terminal status (`completed`, `failed`, or `cancelled`), or until encountering the [`input_required`](#input-required-status) status. Note that invoking `tasks/result` does not imply that the requestor needs to stop polling - requestors **SHOULD** continue polling the task status via `tasks/get` if they are not actively waiting for `tasks/result` to complete.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tasks/get",
+  "params": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "working",
+    "statusMessage": "The operation is now in progress.",
+    "createdAt": "2025-11-25T10:30:00Z",
+    "lastUpdatedAt": "2025-11-25T10:40:00Z",
+    "ttl": 30000,
+    "pollInterval": 5000
+  }
+}
+```
+
+### Retrieving Task Results
+
+<Note>
+
+In the Streamable HTTP (SSE) transport, clients **MAY** disconnect from an SSE stream opened by the server in response to a `tasks/result` request at any time.
+
+While this note is not prescriptive regarding the specific usage of SSE streams, all implementations **MUST** continue to comply with the existing [Streamable HTTP transport specification](../transports#sending-messages-to-the-server).
+
+</Note>
+
+After a task completes the operation result is retrieved via [`tasks/result`](/specification/2025-11-25/schema#tasks%2Fresult). This is distinct from the initial `CreateTaskResult` response, which contains only task data. The result structure matches the original request type (e.g., `CallToolResult` for `tools/call`).
+
+To retrieve the result of a completed task, requestors can send a `tasks/result` request:
+
+While `tasks/result` blocks until the task reaches a terminal status, requestors can continue polling via `tasks/get` in parallel if they are not actively blocked waiting for the result, such as if their previous `tasks/result` request failed or was cancelled. This allows requestors to monitor status changes or display progress updates while the task executes, even after invoking `tasks/result`.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tasks/result",
+  "params": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy"
+      }
+    ],
+    "isError": false,
+    "_meta": {
+      "io.modelcontextprotocol/related-task": {
+        "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+      }
+    }
+  }
+}
+```
+
+### Task Status Notification
+
+When a task status changes, receivers **MAY** send a [`notifications/tasks/status`](/specification/2025-11-25/schema#notifications%2Ftasks%2Fstatus) notification to inform the requestor of the change. This notification includes the full task state.
+
+**Notification:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/tasks/status",
+  "params": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "completed",
+    "createdAt": "2025-11-25T10:30:00Z",
+    "lastUpdatedAt": "2025-11-25T10:50:00Z",
+    "ttl": 60000,
+    "pollInterval": 5000
+  }
+}
+```
+
+The notification includes the full [`Task`](/specification/2025-11-25/schema#task) object, including the updated `status` and `statusMessage` (if present). This allows requestors to access the complete task state without making an additional `tasks/get` request.
+
+Requestors **MUST NOT** rely on receiving this notifications, as it is optional. Receivers are not required to send status notifications and may choose to only send them for certain status transitions. Requestors **SHOULD** continue to poll via `tasks/get` to ensure they receive status updates.
+
+### Listing Tasks
+
+To retrieve a list of tasks, requestors can send a [`tasks/list`](/specification/2025-11-25/schema#tasks%2Flist) request. This operation supports pagination.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "tasks/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "tasks": [
+      {
+        "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+        "status": "working",
+        "createdAt": "2025-11-25T10:30:00Z",
+        "lastUpdatedAt": "2025-11-25T10:40:00Z",
+        "ttl": 30000,
+        "pollInterval": 5000
+      },
+      {
+        "taskId": "abc123-def456-ghi789",
+        "status": "completed",
+        "createdAt": "2025-11-25T09:15:00Z",
+        "lastUpdatedAt": "2025-11-25T10:40:00Z",
+        "ttl": 60000
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Cancelling Tasks
+
+To explicitly cancel a task, requestors can send a [`tasks/cancel`](/specification/2025-11-25/schema#tasks%2Fcancel) request.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "tasks/cancel",
+  "params": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "cancelled",
+    "statusMessage": "The task was cancelled by request.",
+    "createdAt": "2025-11-25T10:30:00Z",
+    "lastUpdatedAt": "2025-11-25T10:40:00Z",
+    "ttl": 30000,
+    "pollInterval": 5000
+  }
+}
+```
+
+## Behavior Requirements
+
+These requirements apply to all parties that support receiving task-augmented requests.
+
+### Task Support and Handling
+
+1. Receivers that do not declare the task capability for a request type **MUST** process requests of that type normally, ignoring any task-augmentation metadata if present.
+1. Receivers that declare the task capability for a request type **MAY** return an error for non-task-augmented requests, requiring requestors to use task augmentation.
+
+### Task ID Requirements
+
+1. Task IDs **MUST** be a string value.
+1. Task IDs **MUST** be generated by the receiver when creating a task.
+1. Task IDs **MUST** be unique among all tasks controlled by the receiver.
+
+### Task Status Lifecycle
+
+1. Tasks **MUST** begin in the `working` status when created.
+1. Receivers **MUST** only transition tasks through the following valid paths:
+   1. From `working`: may move to `input_required`, `completed`, `failed`, or `cancelled`
+   1. From `input_required`: may move to `working`, `completed`, `failed`, or `cancelled`
+   1. Tasks with a `completed`, `failed`, or `cancelled` status are in a terminal state and **MUST NOT** transition to any other status
+
+**Task Status State Diagram:**
+
+```mermaid
+stateDiagram-v2
+    [*] --> working
+
+    working --> input_required
+    working --> terminal
+
+    input_required --> working
+    input_required --> terminal
+
+    terminal --> [*]
+
+    note right of terminal
+        Terminal states:
+        • completed
+        • failed
+        • cancelled
+    end note
+```
+
+### Input Required Status
+
+<Note>
+
+With the Streamable HTTP (SSE) transport, servers often close SSE streams after delivering a response message, which can lead to ambiguity regarding the stream used for subsequent task messages.
+
+Servers can handle this by enqueueing messages to the client to side-channel task-related messages alongside other responses.
+
+Servers have flexibility in how they manage SSE streams during task polling and result retrieval, and clients **SHOULD** expect messages to be delivered on any SSE stream, including the HTTP GET stream.
+One possible approach is maintaining an SSE stream on `tasks/result` (see notes on the `input_required` status).
+Where possible, servers **SHOULD NOT** upgrade to an SSE stream in response to a `tasks/get` request, as the client has indicated it wishes to poll for a result.
+
+While this note is not prescriptive regarding the specific usage of SSE streams, all implementations **MUST** continue to comply with the existing [Streamable HTTP transport specification](../transports#sending-messages-to-the-server).
+
+</Note>
+
+1. When the task receiver has messages for the requestor that are necessary to complete the task, the receiver **SHOULD** move the task to the `input_required` status.
+1. The receiver **MUST** include the `io.modelcontextprotocol/related-task` metadata in the request to associate it with the task.
+1. When the requestor encounters the `input_required` status, it **SHOULD** preemptively call `tasks/result`.
+1. When the receiver receives all required input, the task **SHOULD** transition out of `input_required` status (typically back to `working`).
+
+### TTL and Resource Management
+
+1. Receivers **MUST** include a `createdAt` [ISO 8601](https://datatracker.ietf.org/doc/html/rfc3339#section-5)-formatted timestamp in all task responses to indicate when the task was created.
+1. Receivers **MUST** include a `lastUpdatedAt` [ISO 8601](https://datatracker.ietf.org/doc/html/rfc3339#section-5)-formatted timestamp in all task responses to indicate when the task was last updated.
+1. Receivers **MAY** override the requested `ttl` duration.
+1. Receivers **MUST** include the actual `ttl` duration (or `null` for unlimited) in `tasks/get` responses.
+1. After a task's `ttl` lifetime has elapsed, receivers **MAY** delete the task and its results, regardless of the task status.
+1. Receivers **MAY** include a `pollInterval` value (in milliseconds) in `tasks/get` responses to suggest polling intervals. Requestors **SHOULD** respect this value when provided.
+
+### Result Retrieval
+
+1. Receivers that accept a task-augmented request **MUST** return a `CreateTaskResult` as the response. This result **SHOULD** be returned as soon as possible after accepting the task.
+1. When a receiver receives a `tasks/result` request for a task in a terminal status (`completed`, `failed`, or `cancelled`), it **MUST** return the final result of the underlying request, whether that is a successful result or a JSON-RPC error.
+1. When a receiver receives a `tasks/result` request for a task in any other non-terminal status (`working` or `input_required`), it **MUST** block the response until the task reaches a terminal status.
+1. For tasks in a terminal status, receivers **MUST** return from `tasks/result` exactly what the underlying request would have returned, whether that is a successful result or a JSON-RPC error.
+
+### Associating Task-Related Messages
+
+1. All requests, notifications, and responses related to a task **MUST** include the `io.modelcontextprotocol/related-task` key in their `_meta` field, with the value set to an object with a `taskId` matching the associated task ID.
+   1. For example, an elicitation that a task-augmented tool call depends on **MUST** share the same related task ID with that tool call's task.
+1. For the `tasks/get`, `tasks/result`, and `tasks/cancel` operations, the `taskId` parameter in the request **MUST** be used as the source of truth for identifying the target task. Requestors **SHOULD NOT** include `io.modelcontextprotocol/related-task` metadata in these requests, and receivers **MUST** ignore such metadata if present in favor of the RPC method parameter.
+   Similarly, for the `tasks/get`, `tasks/list`, and `tasks/cancel` operations, receivers **SHOULD NOT** include `io.modelcontextprotocol/related-task` metadata in the result messages, as the `taskId` is already present in the response structure.
+
+### Task Notifications
+
+1. Receivers **MAY** send `notifications/tasks/status` notifications when a task's status changes.
+1. Requestors **MUST NOT** rely on receiving the `notifications/tasks/status` notification, as it is optional.
+1. When sent, the `notifications/tasks/status` notification **SHOULD NOT** include the `io.modelcontextprotocol/related-task` metadata, as the task ID is already present in the notification parameters.
+
+### Task Progress Notifications
+
+Task-augmented requests support progress notifications as defined in the [progress](./progress) specification. The `progressToken` provided in the initial request remains valid throughout the task lifetime.
+
+### Task Listing
+
+1. Receivers **SHOULD** use cursor-based pagination to limit the number of tasks returned in a single response.
+1. Receivers **MUST** include a `nextCursor` in the response if more tasks are available.
+1. Requestors **MUST** treat cursors as opaque tokens and not attempt to parse or modify them.
+1. If a task is retrievable via `tasks/get` for a requestor, it **MUST** be retrievable via `tasks/list` for that requestor.
+
+### Task Cancellation
+
+1. Receivers **MUST** reject cancellation requests for tasks already in a terminal status (`completed`, `failed`, or `cancelled`) with error code `-32602` (Invalid params).
+1. Upon receiving a valid cancellation request, receivers **SHOULD** attempt to stop the task execution and **MUST** transition the task to `cancelled` status before sending the response.
+1. Once a task is cancelled, it **MUST** remain in `cancelled` status even if execution continues to completion or fails.
+1. The `tasks/cancel` operation does not define deletion behavior. However, receivers **MAY** delete cancelled tasks at their discretion at any time, including immediately after cancellation or after the task `ttl` expires.
+1. Requestors **SHOULD NOT** rely on cancelled tasks being retained for any specific duration and should retrieve any needed information before cancelling.
+
+## Message Flow
+
+### Basic Task Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant C as Client (Requestor)
+    participant S as Server (Receiver)
+    Note over C,S: 1. Task Creation
+    C->>S: Request with task field (ttl)
+    activate S
+    S->>C: CreateTaskResult (taskId, status: working, ttl, pollInterval)
+    deactivate S
+    Note over C,S: 2. Task Polling
+    C->>S: tasks/get (taskId)
+    activate S
+    S->>C: working
+    deactivate S
+    Note over S: Task processing continues...
+    C->>S: tasks/get (taskId)
+    activate S
+    S->>C: working
+    deactivate S
+    Note over S: Task completes
+    C->>S: tasks/get (taskId)
+    activate S
+    S->>C: completed
+    deactivate S
+    Note over C,S: 3. Result Retrieval
+    C->>S: tasks/result (taskId)
+    activate S
+    S->>C: Result content
+    deactivate S
+    Note over C,S: 4. Cleanup
+    Note over S: After ttl period from creation, task is cleaned up
+```
+
+### Task-Augmented Tool Call With Elicitation
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant LLM
+    participant C as Client (Requestor)
+    participant S as Server (Receiver)
+
+    Note over LLM,C: LLM initiates request
+    LLM->>C: Request operation
+
+    Note over C,S: Client augments with task
+    C->>S: tools/call (ttl: 3600000)
+    activate S
+    S->>C: CreateTaskResult (task-123, status: working)
+    deactivate S
+
+    Note over LLM,C: Client continues processing other requests<br/>while task executes in background
+    LLM->>C: Request other operation
+    C->>LLM: Other operation result
+
+    Note over C,S: Client polls for status
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: working
+    deactivate S
+
+    Note over S: Server needs information from client<br/>Task moves to input_required
+
+    Note over C,S: Client polls and discovers input_required
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: input_required
+    deactivate S
+
+    Note over C,S: Client opens result stream
+    C->>S: tasks/result (task-123)
+    activate S
+    S->>C: elicitation/create (related-task: task-123)
+    activate C
+    C->>U: Prompt user for input
+    U->>C: Provide information
+    C->>S: elicitation response (related-task: task-123)
+    deactivate C
+    deactivate S
+
+    Note over C,S: Client closes result stream and resumes polling
+
+    Note over S: Task continues processing...<br/>Task moves back to working
+
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: working
+    deactivate S
+
+    Note over S: Task completes
+
+    Note over C,S: Client polls and discovers completion
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: completed
+    deactivate S
+
+    Note over C,S: Client retrieves final results
+    C->>S: tasks/result (task-123)
+    activate S
+    S->>C: Result content
+    deactivate S
+    C->>LLM: Process result
+
+    Note over S: Results retained for ttl period from creation
+```
+
+### Task-Augmented Sampling Request
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant LLM
+    participant C as Client (Receiver)
+    participant S as Server (Requestor)
+
+    Note over S: Server decides to initiate request
+
+    Note over S,C: Server requests client operation (task-augmented)
+    S->>C: sampling/createMessage (ttl: 3600000)
+    activate C
+    C->>S: CreateTaskResult (request-789, status: working)
+    deactivate C
+
+    Note over S: Server continues processing<br/>while waiting for result
+
+    Note over S,C: Server polls for result
+    S->>C: tasks/get (request-789)
+    activate C
+    C->>S: working
+    deactivate C
+
+    Note over C,U: Client may present request to user
+    C->>U: Review request
+    U->>C: Approve request
+
+    Note over C,LLM: Client may involve LLM
+    C->>LLM: Request completion
+    LLM->>C: Return completion
+
+    Note over C,U: Client may present result to user
+    C->>U: Review result
+    U->>C: Approve result
+
+    Note over S,C: Server polls and discovers completion
+    S->>C: tasks/get (request-789)
+    activate C
+    C->>S: completed
+    deactivate C
+
+    Note over S,C: Server retrieves result
+    S->>C: tasks/result (request-789)
+    activate C
+    C->>S: Result content
+    deactivate C
+
+    Note over S: Server continues processing
+
+    Note over C: Results retained for ttl period from creation
+```
+
+### Task Cancellation Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client (Requestor)
+    participant S as Server (Receiver)
+
+    Note over C,S: 1. Task Creation
+    C->>S: tools/call (request ID: 42, ttl: 60000)
+    activate S
+    S->>C: CreateTaskResult (task-123, status: working)
+    deactivate S
+
+    Note over C,S: 2. Task Processing
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: working
+    deactivate S
+
+    Note over C,S: 3. Client Cancellation
+    Note over C: User requests cancellation
+    C->>S: tasks/cancel (taskId: task-123)
+    activate S
+
+    Note over S: Server stops execution (best effort)
+    Note over S: Task moves to cancelled status
+
+    S->>C: Task (status: cancelled)
+    deactivate S
+
+    Note over C: Client receives confirmation
+
+    Note over S: Server may delete task at its discretion
+```
+
+## Data Types
+
+### Task
+
+A task represents the execution state of a request. The task state includes:
+
+- `taskId`: Unique identifier for the task
+- `status`: Current state of the task execution
+- `statusMessage`: Optional human-readable message describing the current state (can be present for any status, including error details for failed tasks)
+- `createdAt`: ISO 8601 timestamp when the task was created
+- `ttl`: Time in milliseconds from creation before task may be deleted
+- `pollInterval`: Suggested time in milliseconds between status checks
+- `lastUpdatedAt`: ISO 8601 timestamp when the task status was last updated
+
+### Task Status
+
+Tasks can be in one of the following states:
+
+- `working`: The request is currently being processed.
+- `input_required`: The receiver needs input from the requestor. The requestor should call `tasks/result` to receive input requests, even though the task has not reached a terminal state.
+- `completed`: The request completed successfully and results are available.
+- `failed`: The associated request did not complete successfully. For tool calls specifically, this includes cases where the tool call result has `isError` set to true.
+- `cancelled`: The request was cancelled before completion.
+
+### Task Parameters
+
+When augmenting a request with task execution, the `task` field is included in the request parameters:
+
+```json
+{
+  "task": {
+    "ttl": 60000
+  }
+}
+```
+
+Fields:
+
+- `ttl` (number, optional): Requested duration in milliseconds to retain task from creation
+
+### Related Task Metadata
+
+All requests, responses, and notifications associated with a task **MUST** include the `io.modelcontextprotocol/related-task` key in `_meta`:
+
+```json
+{
+  "io.modelcontextprotocol/related-task": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+  }
+}
+```
+
+This associates messages with their originating task across the entire request lifecycle.
+
+For the `tasks/get`, `tasks/list`, and `tasks/cancel` operations, requestors and receivers **SHOULD NOT** include this metadata in their messages, as the `taskId` is already present in the message structure.
+The `tasks/result` operation **MUST** include this metadata in its response, as the result structure itself does not contain the task ID.
+
+## Error Handling
+
+Tasks use two error reporting mechanisms:
+
+1. **Protocol Errors**: Standard JSON-RPC errors for protocol-level issues
+1. **Task Execution Errors**: Errors in the underlying request execution, reported through task status
+
+### Protocol Errors
+
+Receivers **MUST** return standard JSON-RPC errors for the following protocol error cases:
+
+- Invalid or nonexistent `taskId` in `tasks/get`, `tasks/result`, or `tasks/cancel`: `-32602` (Invalid params)
+- Invalid or nonexistent cursor in `tasks/list`: `-32602` (Invalid params)
+- Attempt to cancel a task already in a terminal status: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+Additionally, receivers **MAY** return the following errors:
+
+- Non-task-augmented request when receiver requires task augmentation for that request type: `-32600` (Invalid request)
+
+Receivers **SHOULD** provide informative error messages to describe the cause of errors.
+
+**Example: Task augmentation required**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32600,
+    "message": "Task augmentation required for tools/call requests"
+  }
+}
+```
+
+**Example: Task not found**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 70,
+  "error": {
+    "code": -32602,
+    "message": "Failed to retrieve task: Task not found"
+  }
+}
+```
+
+**Example: Task expired**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 71,
+  "error": {
+    "code": -32602,
+    "message": "Failed to retrieve task: Task has expired"
+  }
+}
+```
+
+<Note>
+
+Receivers are not required to retain tasks indefinitely. It is compliant behavior for a receiver to return an error stating the task cannot be found if it has purged an expired task.
+
+</Note>
+
+**Example: Task cancellation rejected (already terminal)**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 74,
+  "error": {
+    "code": -32602,
+    "message": "Cannot cancel task: already in terminal status 'completed'"
+  }
+}
+```
+
+### Task Execution Errors
+
+When the underlying request does not complete successfully, the task moves to the `failed` status. This includes JSON-RPC protocol errors during request execution, or for tool calls specifically, when the tool result has `isError` set to true. The `tasks/get` response **SHOULD** include a `statusMessage` field with diagnostic information about the failure.
+
+**Example: Task with execution error**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f820fe840",
+    "status": "failed",
+    "createdAt": "2025-11-25T10:30:00Z",
+    "lastUpdatedAt": "2025-11-25T10:40:00Z",
+    "ttl": 30000,
+    "statusMessage": "Tool execution failed: API rate limit exceeded"
+  }
+}
+```
+
+For tasks that wrap tool call requests, when the tool result has `isError` set to `true`, the task should reach `failed` status.
+
+The `tasks/result` endpoint returns exactly what the underlying request would have returned:
+
+- If the underlying request resulted in a JSON-RPC error, `tasks/result` **MUST** return that same JSON-RPC error.
+- If the request completed with a JSON-RPC response, `tasks/result` **MUST** return a successful JSON-RPC response containing that result.
+
+## Security Considerations
+
+### Task Isolation and Access Control
+
+Task IDs are the primary mechanism for accessing task state and results. Without proper access controls, any party that can guess or obtain a task ID could potentially access sensitive information or manipulate tasks they did not create.
+
+When an authorization context is provided, receivers **MUST** bind tasks to said context.
+
+Context-binding is not practical for all applications. Some MCP servers operate in environments without authorization, such as single-user tools, or use transports that don't support authorization.
+In these scenarios, receivers **SHOULD** document this limitation clearly, as task results may be accessible to any requestor that can guess the task ID.
+If context-binding is unavailable, receivers **MUST** generate cryptographically secure task IDs with enough entropy to prevent guessing and should consider using shorter TTL durations to reduce the exposure window.
+Furthermore, receivers that cannot identify requestors **SHOULD NOT** declare the `tasks.list` capability, as listing tasks would expose task metadata to any requestor regardless of task ID entropy.
+
+If context-binding is available, receivers **MUST** reject `tasks/get`, `tasks/result`, and `tasks/cancel` requests for tasks that do not belong to the same authorization context as the requestor. For `tasks/list` requests, receivers **MUST** ensure the returned task list includes only tasks associated with the requestor's authorization context.
+
+Additionally, receivers **SHOULD** implement rate limiting on task operations to prevent denial-of-service and enumeration attacks.
+
+### Resource Management
+
+1. Receivers **SHOULD**:
+   1. Enforce limits on concurrent tasks per requestor
+   1. Enforce maximum `ttl` durations to prevent indefinite resource retention
+   1. Clean up expired tasks promptly to free resources
+   1. Document maximum supported `ttl` duration
+   1. Document maximum concurrent tasks per requestor
+   1. Implement monitoring and alerting for resource usage
+
+### Audit and Logging
+
+1. Receivers **SHOULD**:
+   1. Log task creation, completion, and retrieval events for audit purposes
+   1. Include auth context in logs when available
+   1. Monitor for suspicious patterns (e.g., many failed task lookups, excessive polling)
+1. Requestors **SHOULD**:
+   1. Log task lifecycle events for debugging and audit purposes
+   1. Track task IDs and their associated operations

--- a/spec/transports.md
+++ b/spec/transports.md
@@ -4,8 +4,6 @@ title: Transports
 
 <div id="enable-section-numbers" />
 
-<Info>**Protocol Revision**: 2025-06-18</Info>
-
 MCP uses JSON-RPC to encode messages. JSON-RPC messages **MUST** be UTF-8 encoded.
 
 The protocol currently defines two standard transport mechanisms for client-server
@@ -28,8 +26,10 @@ In the **stdio** transport:
   to its standard output (`stdout`).
 - Messages are individual JSON-RPC requests, notifications, or responses.
 - Messages are delimited by newlines, and **MUST NOT** contain embedded newlines.
-- The server **MAY** write UTF-8 strings to its standard error (`stderr`) for logging
-  purposes. Clients **MAY** capture, forward, or ignore this logging.
+- The server **MAY** write UTF-8 strings to its standard error (`stderr`) for any
+  logging purposes including informational, debug, and error messages.
+- The client **MAY** capture, forward, or ignore the server's `stderr` output
+  and **SHOULD NOT** assume `stderr` output indicates error conditions.
 - The server **MUST NOT** write anything to its `stdout` that is not a valid MCP message.
 - The client **MUST NOT** write anything to the server's `stdin` that is not a valid MCP
   message.
@@ -76,6 +76,8 @@ URL like `https://example.com/mcp`.
 When implementing Streamable HTTP transport:
 
 1. Servers **MUST** validate the `Origin` header on all incoming connections to prevent DNS rebinding attacks
+   - If the `Origin` header is present and invalid, servers **MUST** respond with HTTP 403 Forbidden. The HTTP response
+     body **MAY** comprise a JSON-RPC _error response_ that has no `id`
 2. When running locally, servers **SHOULD** bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
 3. Servers **SHOULD** implement proper authentication for all connections
 
@@ -101,16 +103,26 @@ MCP endpoint.
    `Content-Type: application/json`, to return one JSON object. The client **MUST**
    support both these cases.
 6. If the server initiates an SSE stream:
-   - The SSE stream **SHOULD** eventually include JSON-RPC _response_ for the
+   - The server **SHOULD** immediately send an SSE event consisting of an event
+     ID and an empty `data` field in order to prime the client to reconnect
+     (using that event ID as `Last-Event-ID`).
+   - After the server has sent an SSE event with an event ID to the client, the
+     server **MAY** close the _connection_ (without terminating the _SSE stream_)
+     at any time in order to avoid holding a long-lived connection. The client
+     **SHOULD** then "poll" the SSE stream by attempting to reconnect.
+   - If the server does close the _connection_ prior to terminating the _SSE stream_,
+     it **SHOULD** send an SSE event with a standard [`retry`](https://html.spec.whatwg.org/multipage/server-sent-events.html#:~:text=field%20name%20is%20%22retry%22) field before
+     closing the connection. The client **MUST** respect the `retry` field,
+     waiting the given number of milliseconds before attempting to reconnect.
+   - The SSE stream **SHOULD** eventually include a JSON-RPC _response_ for the
      JSON-RPC _request_ sent in the POST body.
    - The server **MAY** send JSON-RPC _requests_ and _notifications_ before sending the
      JSON-RPC _response_. These messages **SHOULD** relate to the originating client
      _request_.
-   - The server **SHOULD NOT** close the SSE stream before sending the JSON-RPC _response_
-     for the received JSON-RPC _request_, unless the [session](#session-management)
+   - The server **MAY** terminate the SSE stream if the [session](#session-management)
      expires.
-   - After the JSON-RPC _response_ has been sent, the server **SHOULD** close the SSE
-     stream.
+   - After the JSON-RPC _response_ has been sent, the server **SHOULD** terminate the
+     SSE stream.
    - Disconnection **MAY** occur at any time (e.g., due to network conditions).
      Therefore:
      - Disconnection **SHOULD NOT** be interpreted as the client cancelling its request.
@@ -136,6 +148,9 @@ MCP endpoint.
      [resuming](#resumability-and-redelivery) a stream associated with a previous client
      request.
    - The server **MAY** close the SSE stream at any time.
+   - If the server closes the _connection_ without terminating the _stream_, it
+     **SHOULD** follow the same polling behavior as described for POST requests:
+     sending a `retry` field and allowing the client to reconnect.
    - The client **MAY** close the SSE stream at any time.
 
 ### Multiple Connections
@@ -156,8 +171,11 @@ lost:
    - If present, the ID **MUST** be globally unique across all streams within that
      [session](#session-management)—or all streams with that specific client, if session
      management is not in use.
-2. If the client wishes to resume after a broken connection, it **SHOULD** issue an HTTP
-   GET to the MCP endpoint, and include the
+   - Event IDs **SHOULD** encode sufficient information to identify the originating
+     stream, enabling the server to correlate a `Last-Event-ID` to the correct stream.
+2. If the client wishes to resume after a disconnection (whether due to network failure
+   or server-initiated closure), it **SHOULD** issue an HTTP GET to the MCP endpoint,
+   and include the
    [`Last-Event-ID`](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header)
    header to indicate the last event ID it received.
    - The server **MAY** use this header to replay messages that would have been sent
@@ -165,6 +183,8 @@ lost:
      stream from that point.
    - The server **MUST NOT** replay messages that would have been delivered on a
      different stream.
+   - This mechanism applies regardless of how the original stream was initiated (via
+     POST or GET). Resumption is always via HTTP GET with `Last-Event-ID`.
 
 In other words, these event IDs should be assigned by servers on a _per-stream_ basis, to
 act as a cursor within that particular stream.
@@ -172,29 +192,30 @@ act as a cursor within that particular stream.
 ### Session Management
 
 An MCP "session" consists of logically related interactions between a client and a
-server, beginning with the [initialization phase](/specification/2025-06-18/basic/lifecycle). To support
+server, beginning with the [initialization phase](/specification/2025-11-25/basic/lifecycle). To support
 servers which want to establish stateful sessions:
 
 1. A server using the Streamable HTTP transport **MAY** assign a session ID at
-   initialization time, by including it in an `Mcp-Session-Id` header on the HTTP
+   initialization time, by including it in an `MCP-Session-Id` header on the HTTP
    response containing the `InitializeResult`.
    - The session ID **SHOULD** be globally unique and cryptographically secure (e.g., a
      securely generated UUID, a JWT, or a cryptographic hash).
    - The session ID **MUST** only contain visible ASCII characters (ranging from 0x21 to
      0x7E).
-2. If an `Mcp-Session-Id` is returned by the server during initialization, clients using
-   the Streamable HTTP transport **MUST** include it in the `Mcp-Session-Id` header on
+   - The client **MUST** handle the session ID in a secure manner, see [Session Hijacking mitigations](/specification/2025-11-25/basic/security_best_practices#session-hijacking) for more details.
+2. If an `MCP-Session-Id` is returned by the server during initialization, clients using
+   the Streamable HTTP transport **MUST** include it in the `MCP-Session-Id` header on
    all of their subsequent HTTP requests.
    - Servers that require a session ID **SHOULD** respond to requests without an
-     `Mcp-Session-Id` header (other than initialization) with HTTP 400 Bad Request.
+     `MCP-Session-Id` header (other than initialization) with HTTP 400 Bad Request.
 3. The server **MAY** terminate the session at any time, after which it **MUST** respond
    to requests containing that session ID with HTTP 404 Not Found.
 4. When a client receives HTTP 404 in response to a request containing an
-   `Mcp-Session-Id`, it **MUST** start a new session by sending a new `InitializeRequest`
+   `MCP-Session-Id`, it **MUST** start a new session by sending a new `InitializeRequest`
    without a session ID attached.
 5. Clients that no longer need a particular session (e.g., because the user is leaving
    the client application) **SHOULD** send an HTTP DELETE to the MCP endpoint with the
-   `Mcp-Session-Id` header, to explicitly terminate the session.
+   `MCP-Session-Id` header, to explicitly terminate the session.
    - The server **MAY** respond to this request with HTTP 405 Method Not Allowed,
      indicating that the server does not allow clients to terminate sessions.
 
@@ -208,13 +229,13 @@ sequenceDiagram
     note over Client, Server: initialization
 
     Client->>+Server: POST InitializeRequest
-    Server->>-Client: InitializeResponse<br>Mcp-Session-Id: 1868a90c...
+    Server->>-Client: InitializeResponse<br>MCP-Session-Id: 1868a90c...
 
-    Client->>+Server: POST InitializedNotification<br>Mcp-Session-Id: 1868a90c...
+    Client->>+Server: POST InitializedNotification<br>MCP-Session-Id: 1868a90c...
     Server->>-Client: 202 Accepted
 
     note over Client, Server: client requests
-    Client->>+Server: POST ... request ...<br>Mcp-Session-Id: 1868a90c...
+    Client->>+Server: POST ... request ...<br>MCP-Session-Id: 1868a90c...
 
     alt single HTTP response
       Server->>Client: ... response ...
@@ -227,11 +248,11 @@ sequenceDiagram
     deactivate Server
 
     note over Client, Server: client notifications/responses
-    Client->>+Server: POST ... notification/response ...<br>Mcp-Session-Id: 1868a90c...
+    Client->>+Server: POST ... notification/response ...<br>MCP-Session-Id: 1868a90c...
     Server->>-Client: 202 Accepted
 
     note over Client, Server: server requests
-    Client->>+Server: GET<br>Mcp-Session-Id: 1868a90c...
+    Client->>+Server: GET<br>MCP-Session-Id: 1868a90c...
     loop while connection remains open
         Server-)Client: ... SSE messages from server ...
     end
@@ -245,10 +266,10 @@ If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
 <protocol-version>` HTTP header on all subsequent requests to the MCP
 server, allowing the MCP server to respond based on the MCP protocol version.
 
-For example: `MCP-Protocol-Version: 2025-06-18`
+For example: `MCP-Protocol-Version: 2025-11-25`
 
 The protocol version sent by the client **SHOULD** be the one [negotiated during
-initialization](/specification/2025-06-18/basic/lifecycle#version-negotiation).
+initialization](/specification/2025-11-25/basic/lifecycle#version-negotiation).
 
 For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
 header, and has no other way to identify the version - for example, by relying on the
@@ -279,8 +300,8 @@ protocol version 2024-11-05) as follows:
    defined above:
    - If it succeeds, the client can assume this is a server supporting the new Streamable
      HTTP transport.
-   - If it fails with an HTTP 4xx status code (e.g., 405 Method Not Allowed or 404 Not
-     Found):
+   - If it fails with the following HTTP status codes "400 Bad Request", "404 Not
+     Found" or "405 Method Not Allowed":
      - Issue a GET request to the server URL, expecting that this will open an SSE stream
        and return an `endpoint` event as the first event.
      - When the `endpoint` event arrives, the client can assume this is a server running

--- a/src/auth/oauth-client.ts
+++ b/src/auth/oauth-client.ts
@@ -10,7 +10,19 @@ export interface OAuthClientConfig {
   resourceUri?: string
   scopes?: string[]
   dynamicRegistration?: boolean
+  /**
+   * OAuth Client ID Metadata Document (SEP-991), the registration mechanism
+   * recommended from 2025-11-25 on. When enabled we publish our client metadata
+   * as JSON and use its HTTPS URL as the `client_id`, so no registration call —
+   * dynamic or manual — is needed against the authorization server.
+   *
+   * Pass `true` for the default path, or an object to override it.
+   */
+  clientIdMetadataDocument?: boolean | { path?: string }
 }
+
+/** Where the client metadata document is served unless overridden */
+export const DEFAULT_CLIENT_ID_METADATA_PATH = '/.well-known/oauth-client'
 
 export interface PKCEChallenge {
   codeVerifier: string
@@ -65,6 +77,42 @@ interface OIDCEndpoints {
 const discoveryCache = new Map<string, { endpoints: OIDCEndpoints; timestamp: number }>()
 const DISCOVERY_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
 
+/**
+ * Build the ordered list of metadata URLs to try for an issuer.
+ *
+ * The 2025-11-25 revision (SEP-797) requires supporting OpenID Connect Discovery
+ * 1.0 alongside RFC 8414. Issuers with a path component have two spellings each,
+ * so the full chain is:
+ *
+ * 1. RFC 8414 path-insertion:  `{origin}/.well-known/oauth-authorization-server{path}`
+ * 2. OIDC path-insertion:      `{origin}/.well-known/openid-configuration{path}`
+ * 3. OIDC path-appending:      `{issuer}/.well-known/openid-configuration`
+ *
+ * For an issuer without a path all three collapse to two distinct URLs.
+ */
+export function buildDiscoveryUrls (authorizationServer: string): string[] {
+  const issuer = authorizationServer.replace(/\/$/, '')
+
+  let origin: string
+  let path: string
+  try {
+    const url = new URL(issuer)
+    origin = url.origin
+    path = url.pathname === '/' ? '' : url.pathname
+  } catch {
+    // Not a parseable URL; fall back to simple appending
+    return [`${issuer}/.well-known/openid-configuration`]
+  }
+
+  const urls = [
+    `${origin}/.well-known/oauth-authorization-server${path}`,
+    `${origin}/.well-known/openid-configuration${path}`,
+    `${issuer}/.well-known/openid-configuration`
+  ]
+
+  return [...new Set(urls)]
+}
+
 async function discoverOIDCEndpoints (
   authorizationServer: string,
   logger?: FastifyBaseLogger
@@ -76,27 +124,30 @@ async function discoverOIDCEndpoints (
     return cached.endpoints
   }
 
-  try {
-    const discoveryUrl = `${authorizationServer}/.well-known/openid-configuration`
-    logger?.info({ discoveryUrl }, 'OAuth client: fetching OIDC discovery document')
+  for (const discoveryUrl of buildDiscoveryUrls(authorizationServer)) {
+    try {
+      logger?.info({ discoveryUrl }, 'OAuth client: fetching authorization server metadata')
 
-    const response = await fetch(discoveryUrl)
-    if (response.ok) {
-      const metadata = await response.json() as Record<string, string>
-      const endpoints: OIDCEndpoints = {
-        authorizationEndpoint: metadata.authorization_endpoint,
-        tokenEndpoint: metadata.token_endpoint,
-        introspectionEndpoint: metadata.introspection_endpoint,
-        registrationEndpoint: metadata.registration_endpoint
+      const response = await fetch(discoveryUrl)
+      if (response.ok) {
+        const metadata = await response.json() as Record<string, string>
+        const endpoints: OIDCEndpoints = {
+          authorizationEndpoint: metadata.authorization_endpoint,
+          tokenEndpoint: metadata.token_endpoint,
+          introspectionEndpoint: metadata.introspection_endpoint,
+          registrationEndpoint: metadata.registration_endpoint
+        }
+        discoveryCache.set(authorizationServer, { endpoints, timestamp: now })
+        logger?.info({ discoveryUrl, endpoints }, 'OAuth client: authorization server metadata discovered')
+        return endpoints
       }
-      discoveryCache.set(authorizationServer, { endpoints, timestamp: now })
-      logger?.info({ endpoints }, 'OAuth client: OIDC endpoints discovered')
-      return endpoints
+      logger?.debug({ discoveryUrl, status: response.status }, 'OAuth client: metadata endpoint returned non-OK, trying next')
+    } catch (error) {
+      logger?.debug({ discoveryUrl, error: error instanceof Error ? error.message : String(error) }, 'OAuth client: metadata fetch failed, trying next')
     }
-    logger?.warn({ status: response.status }, 'OAuth client: OIDC discovery failed, using defaults')
-  } catch (error) {
-    logger?.warn({ error: error instanceof Error ? error.message : String(error) }, 'OAuth client: OIDC discovery error, using defaults')
   }
+
+  logger?.warn({ authorizationServer }, 'OAuth client: discovery exhausted all well-known locations, using defaults')
 
   // Default endpoints (original behavior for backwards compatibility)
   const defaults: OIDCEndpoints = {
@@ -109,9 +160,47 @@ async function discoverOIDCEndpoints (
   return defaults
 }
 
+/**
+ * Build the client metadata document we publish when using CIMD (SEP-991).
+ * `client_id` must equal the URL the document is served from.
+ */
+export function buildClientIdMetadataDocument (opts: OAuthClientConfig, documentUrl: string): Record<string, unknown> {
+  return {
+    client_id: documentUrl,
+    client_name: 'MCP Server',
+    client_uri: opts.resourceUri,
+    redirect_uris: [`${opts.resourceUri}/oauth/callback`],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+    scope: (opts.scopes || ['read']).join(' ')
+  }
+}
+
 const oauthClientPlugin: FastifyPluginAsync<OAuthClientConfig> = async (fastify, opts) => {
   // Discover OIDC endpoints on startup
   const endpoints = await discoverOIDCEndpoints(opts.authorizationServer, fastify.log)
+
+  // SEP-991: publish a client metadata document and adopt its URL as our client_id
+  if (opts.clientIdMetadataDocument) {
+    const path = (typeof opts.clientIdMetadataDocument === 'object' && opts.clientIdMetadataDocument.path) ||
+      DEFAULT_CLIENT_ID_METADATA_PATH
+
+    if (!opts.resourceUri) {
+      throw new Error('clientIdMetadataDocument requires resourceUri so the document URL can be resolved')
+    }
+
+    const documentUrl = `${opts.resourceUri.replace(/\/$/, '')}${path}`
+    const document = buildClientIdMetadataDocument(opts, documentUrl)
+
+    fastify.get(path, async (_request, reply) => {
+      return reply.type('application/json').send(document)
+    })
+
+    // The document URL *is* the client identifier, so registration is unnecessary
+    opts.clientId = documentUrl
+    fastify.log.info({ documentUrl }, 'OAuth client: using Client ID Metadata Document as client_id')
+  }
 
   // Our OAuth client implementation is completely independent and doesn't need @fastify/oauth2
   // @fastify/oauth2 can be optionally registered by users if they want the additional routes,

--- a/src/auth/oauth-client.ts
+++ b/src/auth/oauth-client.ts
@@ -193,6 +193,14 @@ const oauthClientPlugin: FastifyPluginAsync<OAuthClientConfig> = async (fastify,
     const documentUrl = `${opts.resourceUri.replace(/\/$/, '')}${path}`
     const document = buildClientIdMetadataDocument(opts, documentUrl)
 
+    // The authorization server fetches this document unauthenticated to resolve
+    // the client_id. The auth preHandler only exempts /.well-known, so a custom
+    // path outside it would sit behind bearer auth and be unreachable (401).
+    if (!path.startsWith('/.well-known/')) {
+      fastify.log.warn({ path },
+        'clientIdMetadataDocument path is outside /.well-known; add it to authorization.excludedPaths or the authorization server will get 401 when fetching it')
+    }
+
     fastify.get(path, async (_request, reply) => {
       return reply.type('application/json').send(document)
     })

--- a/src/auth/prehandler.ts
+++ b/src/auth/prehandler.ts
@@ -64,6 +64,24 @@ export function createAuthPreHandler (
       })
     }
 
+    // SEP-835: the token is good but may not carry everything this resource needs.
+    // Name the missing scopes so the client can run an incremental consent flow.
+    const missingScopes = findMissingScopes(config.requiredScopes, validationResult.payload)
+    if (missingScopes.length > 0) {
+      request.log.warn({ missingScopes }, 'Token is missing required scopes')
+
+      return reply
+        .code(403)
+        .header('WWW-Authenticate', generateWWWAuthenticateHeader(config, {
+          error: 'insufficient_scope',
+          scope: config.requiredScopes
+        }))
+        .send({
+          error: 'insufficient_scope',
+          error_description: `Token is missing required scope(s): ${missingScopes.join(', ')}`
+        })
+    }
+
     // Add token payload to request context for downstream handlers
     // @ts-ignore - Adding custom property to request
     request.tokenPayload = validationResult.payload
@@ -72,12 +90,47 @@ export function createAuthPreHandler (
   }
 }
 
-function generateWWWAuthenticateHeader (config: AuthorizationConfig): string {
+/**
+ * Read the scopes off a validated token, tolerating both the space-delimited
+ * `scope` string of RFC 6749 and the `scopes` array some issuers emit.
+ */
+export function extractTokenScopes (payload: any): string[] {
+  if (!payload) return []
+  if (typeof payload.scope === 'string') {
+    return payload.scope.split(' ').filter(Boolean)
+  }
+  if (Array.isArray(payload.scopes)) {
+    return payload.scopes
+  }
+  return []
+}
+
+export function findMissingScopes (required: string[] | undefined, payload: any): string[] {
+  if (!required || required.length === 0) return []
+  const granted = new Set(extractTokenScopes(payload))
+  return required.filter(scope => !granted.has(scope))
+}
+
+interface WWWAuthenticateChallenge {
+  error?: string
+  scope?: string[]
+}
+
+function generateWWWAuthenticateHeader (config: AuthorizationConfig, challenge: WWWAuthenticateChallenge = {}): string {
   if (!config.enabled) {
     throw new Error('Authorization is disabled')
   }
   const resourceMetadataUrl = `${config.resourceUri}/.well-known/oauth-protected-resource`
-  return `Bearer realm="MCP Server", resource_metadata="${resourceMetadataUrl}"`
+  const params = ['realm="MCP Server"', `resource_metadata="${resourceMetadataUrl}"`]
+
+  if (challenge.error) {
+    params.push(`error="${challenge.error}"`)
+  }
+  if (challenge.scope && challenge.scope.length > 0) {
+    params.push(`scope="${challenge.scope.join(' ')}"`)
+  }
+
+  return `Bearer ${params.join(', ')}`
 }
 
 // Type augmentation for FastifyRequest to include tokenPayload

--- a/src/decorators/pubsub.ts
+++ b/src/decorators/pubsub.ts
@@ -10,6 +10,7 @@ import type {
 import { validateElicitationRequest, validateElicitationUrl } from '../security.ts'
 import { JSONRPC_VERSION } from '../schema.ts'
 import { randomUUID } from 'node:crypto'
+import { supportsUrlElicitation } from '../protocol-version.ts'
 import type { SessionStore } from '../stores/session-store.ts'
 import type { MessageBroker } from '../brokers/message-broker.ts'
 
@@ -109,6 +110,17 @@ const mcpPubSubDecoratorsPlugin: FastifyPluginAsync<MCPPubSubDecoratorsOptions> 
   ): Promise<string | null> => {
     if (!enableSSE) {
       app.log.warn('Cannot send elicitation request: SSE is disabled')
+      return null
+    }
+
+    // URL mode arrived in 2025-11-25; a client on an older revision would not
+    // know what to do with it, so do not send one.
+    const session = await sessionStore.get(sessionId)
+    if (session && !supportsUrlElicitation(session.protocolVersion)) {
+      app.log.warn({
+        sessionId,
+        negotiated: session.protocolVersion
+      }, 'Cannot send URL elicitation: the session negotiated a revision without URL mode')
       return null
     }
 

--- a/src/decorators/pubsub.ts
+++ b/src/decorators/pubsub.ts
@@ -4,11 +4,12 @@ import type {
   JSONRPCMessage,
   JSONRPCNotification,
   JSONRPCRequest,
-  ElicitRequest,
+  ElicitRequestFormParams,
   RequestId
 } from '../schema.ts'
-import { validateElicitationRequest } from '../security.ts'
+import { validateElicitationRequest, validateElicitationUrl } from '../security.ts'
 import { JSONRPC_VERSION } from '../schema.ts'
+import { randomUUID } from 'node:crypto'
 import type { SessionStore } from '../stores/session-store.ts'
 import type { MessageBroker } from '../brokers/message-broker.ts'
 
@@ -61,7 +62,7 @@ const mcpPubSubDecoratorsPlugin: FastifyPluginAsync<MCPPubSubDecoratorsOptions> 
   app.decorate('mcpElicit', async (
     sessionId: string,
     message: string,
-    requestedSchema: ElicitRequest['params']['requestedSchema'],
+    requestedSchema: ElicitRequestFormParams['requestedSchema'],
     requestId?: RequestId
   ): Promise<boolean> => {
     if (!enableSSE) {
@@ -94,6 +95,64 @@ const mcpPubSubDecoratorsPlugin: FastifyPluginAsync<MCPPubSubDecoratorsOptions> 
     }
 
     return await app.mcpSendToSession(sessionId, elicitRequest)
+  })
+
+  // URL mode elicitation (2025-11-25): sends the user out of band for anything
+  // sensitive — credentials, payments, third-party OAuth — so it never passes
+  // through the MCP client.
+  app.decorate('mcpElicitUrl', async (
+    sessionId: string,
+    message: string,
+    url: string,
+    elicitationId?: string,
+    requestId?: RequestId
+  ): Promise<string | null> => {
+    if (!enableSSE) {
+      app.log.warn('Cannot send elicitation request: SSE is disabled')
+      return null
+    }
+
+    try {
+      validateElicitationUrl(message, url)
+    } catch (validationError) {
+      app.log.warn({
+        sessionId,
+        error: validationError instanceof Error ? validationError.message : 'Unknown validation error'
+      }, 'URL elicitation request validation failed')
+      return null
+    }
+
+    const id = elicitationId ?? randomUUID()
+
+    const elicitRequest: JSONRPCRequest = {
+      jsonrpc: JSONRPC_VERSION,
+      id: requestId ?? `elicit-${id}`,
+      method: 'elicitation/create',
+      params: {
+        mode: 'url',
+        message,
+        url,
+        elicitationId: id
+      }
+    }
+
+    const sent = await app.mcpSendToSession(sessionId, elicitRequest)
+    return sent ? id : null
+  })
+
+  // Tell the client an out-of-band interaction finished, so it can retry the
+  // request that triggered it. Must go only to the session that started it.
+  app.decorate('mcpNotifyElicitationComplete', async (
+    sessionId: string,
+    elicitationId: string
+  ): Promise<boolean> => {
+    const notification: JSONRPCNotification = {
+      jsonrpc: JSONRPC_VERSION,
+      method: 'notifications/elicitation/complete',
+      params: { elicitationId }
+    }
+
+    return await app.mcpSendToSession(sessionId, notification)
   })
 }
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import type {
   JSONRPCMessage,
@@ -13,18 +14,24 @@ import type {
   ListPromptsResult,
   CallToolResult,
   ReadResourceResult,
-  GetPromptResult
+  GetPromptResult,
+  CreateTaskResult,
+  ListTasksResult
 } from './schema.ts'
 
 import {
   JSONRPC_VERSION,
   LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
   METHOD_NOT_FOUND,
   INTERNAL_ERROR,
   INVALID_PARAMS
 } from './schema.ts'
 
 import type { MCPTool, MCPResource, MCPPrompt, MCPPluginOptions, ResourceHandlers } from './types.ts'
+import type { SessionStore } from './stores/session-store.ts'
+import type { TaskStore, TaskRecord, TaskWaiters } from './stores/task-store.ts'
+import { isTerminal, toWireTask } from './stores/task-store.ts'
 import type { AuthorizationContext } from './types/auth-types.ts'
 import { validate, CallToolRequestSchema, ReadResourceRequestSchema, GetPromptRequestSchema, isTypeBoxSchema } from './validation/index.ts'
 import { sanitizeToolParams, assessToolSecurity, SECURITY_WARNINGS } from './security.ts'
@@ -41,6 +48,10 @@ type HandlerDependencies = {
   request: FastifyRequest
   reply: FastifyReply
   authContext?: AuthorizationContext
+  sessionStore?: SessionStore
+  taskStore?: TaskStore
+  taskWaiters?: TaskWaiters
+  sessionId?: string
 }
 
 export function createResponse (id: string | number, result: any): JSONRPCResponse {
@@ -59,10 +70,50 @@ export function createError (id: string | number, code: number, message: string,
   }
 }
 
-function handleInitialize (request: JSONRPCRequest, dependencies: HandlerDependencies): JSONRPCResponse {
-  const { opts, capabilities, serverInfo } = dependencies
+/**
+ * Pick the protocol revision to use for this session.
+ *
+ * The spec requires that we echo back the client's requested version when we
+ * support it, and otherwise respond with the newest version we do support so
+ * the client can decide whether to continue or disconnect.
+ */
+export function negotiateProtocolVersion (requested: unknown): string {
+  if (typeof requested === 'string' && (SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(requested)) {
+    return requested
+  }
+  return LATEST_PROTOCOL_VERSION
+}
+
+async function handleInitialize (
+  request: JSONRPCRequest,
+  sessionId: string | undefined,
+  dependencies: HandlerDependencies
+): Promise<JSONRPCResponse> {
+  const { app, opts, capabilities, serverInfo, sessionStore } = dependencies
+
+  const requested = (request.params as { protocolVersion?: unknown } | undefined)?.protocolVersion
+  const protocolVersion = negotiateProtocolVersion(requested)
+
+  if (requested !== undefined && requested !== protocolVersion) {
+    app.log.warn({
+      requested,
+      offered: protocolVersion,
+      sessionId
+    }, 'Unsupported protocol version requested, offering latest supported version')
+  }
+
+  // Remember what we agreed on so later requests can be checked against it
+  if (sessionId && sessionStore) {
+    const session = await sessionStore.get(sessionId)
+    if (session) {
+      session.protocolVersion = protocolVersion
+      session.lastActivity = new Date()
+      await sessionStore.update(session)
+    }
+  }
+
   const result: InitializeResult = {
-    protocolVersion: LATEST_PROTOCOL_VERSION,
+    protocolVersion,
     capabilities,
     serverInfo,
     instructions: opts.instructions
@@ -75,19 +126,33 @@ function handlePing (request: JSONRPCRequest): JSONRPCResponse {
   return createResponse(request.id, result)
 }
 
+/**
+ * SEP-1613 made JSON Schema 2020-12 the default dialect for MCP schemas.
+ * We declare it explicitly on the schemas we publish so clients never have to
+ * guess, while leaving an author-supplied `$schema` untouched.
+ */
+const JSON_SCHEMA_DIALECT = 'https://json-schema.org/draft/2020-12/schema'
+
+function withSchemaDialect<T> (schema: T): T {
+  if (!schema || typeof schema !== 'object') return schema
+  if ('$schema' in (schema as Record<string, unknown>)) return schema
+  return { $schema: JSON_SCHEMA_DIALECT, ...(schema as Record<string, unknown>) } as T
+}
+
 function handleToolsList (request: JSONRPCRequest, dependencies: HandlerDependencies): JSONRPCResponse {
   const { tools } = dependencies
   const result: ListToolsResult = {
     tools: Array.from(tools.values()).map(t => {
       const tool = t.definition
       // TypeBox schemas are already JSON Schema compatible
-      if (isTypeBoxSchema(tool.inputSchema)) {
-        return {
-          ...tool,
-          inputSchema: tool.inputSchema
-        }
+      const serialized: typeof tool = {
+        ...tool,
+        inputSchema: withSchemaDialect(tool.inputSchema)
       }
-      return tool
+      if (serialized.outputSchema) {
+        serialized.outputSchema = withSchemaDialect(serialized.outputSchema)
+      }
+      return serialized
     }),
     nextCursor: undefined
   }
@@ -157,6 +222,34 @@ async function handleToolsCall (
     return createError(request.id, METHOD_NOT_FOUND, `Tool '${toolName}' not found`)
   }
 
+  // Decide up front whether this call runs as a task, so the rest of the
+  // handler can stay unaware of it.
+  const taskParams = (request.params as { task?: { ttl?: number } } | undefined)?.task
+  const augmentation = resolveTaskAugmentation(tool, taskParams !== undefined)
+  if ('error' in augmentation) {
+    return createError(request.id, METHOD_NOT_FOUND, augmentation.error)
+  }
+  if (augmentation.mode === 'task') {
+    return await runToolCallAsTask(
+      request,
+      taskParams?.ttl,
+      () => executeToolCall(request, tool, params, sessionId, dependencies),
+      dependencies
+    )
+  }
+
+  return await executeToolCall(request, tool, params, sessionId, dependencies)
+}
+
+async function executeToolCall (
+  request: JSONRPCRequest,
+  tool: MCPTool,
+  params: { name: string, arguments?: Record<string, unknown> },
+  sessionId: string | undefined,
+  dependencies: HandlerDependencies
+): Promise<JSONRPCResponse | JSONRPCError> {
+  const toolName = params.name
+
   if (!tool.handler) {
     const result: CallToolResult = {
       content: [{
@@ -193,7 +286,16 @@ async function handleToolsCall (
       error: sanitizeError instanceof Error ? sanitizeError.message : 'Unknown sanitization error'
     }, 'Tool arguments sanitization failed')
 
-    return createError(request.id, INVALID_PARAMS, `${SECURITY_WARNINGS.UNVALIDATED_INPUT}: ${sanitizeError instanceof Error ? sanitizeError.message : 'Sanitization failed'}`)
+    // SEP-1303: input validation failures are tool execution errors, not protocol
+    // errors, so the model gets a chance to correct itself.
+    const result: CallToolResult = {
+      content: [{
+        type: 'text',
+        text: `${SECURITY_WARNINGS.UNVALIDATED_INPUT}: ${sanitizeError instanceof Error ? sanitizeError.message : 'Sanitization failed'}`
+      }],
+      isError: true
+    }
+    return createResponse(request.id, result)
   }
   if ('inputSchema' in tool.definition) {
     // Check if it's a TypeBox schema
@@ -476,6 +578,300 @@ async function handlePromptsGet (
   }
 }
 
+/* ---------------------------------------------------------------- tasks --- */
+
+/** `_meta` key that ties every task-related message back to its task */
+export const RELATED_TASK_META_KEY = 'io.modelcontextprotocol/related-task'
+
+/** Suggested client polling interval, in milliseconds */
+const DEFAULT_POLL_INTERVAL = 1000
+
+/** Retention applied when the requestor does not ask for a specific ttl */
+const DEFAULT_TASK_TTL = 60_000
+
+/** Ceiling on retention, so a client cannot pin resources indefinitely */
+const MAX_TASK_TTL = 3600_000
+
+/**
+ * The authorization subject a task belongs to.
+ *
+ * When the deployment cannot identify requestors this is undefined, and tasks
+ * are reachable by anyone holding the (cryptographically random) task id. That
+ * limitation is why `tasks/list` is only advertised when auth is in play.
+ */
+function taskSubject (dependencies: HandlerDependencies): string | undefined {
+  return dependencies.authContext?.userId
+}
+
+/**
+ * Enforce task isolation: a requestor may only touch its own tasks.
+ * Returns an "invalid params" error rather than a distinct "forbidden" code so
+ * that probing for task ids cannot distinguish existence from ownership.
+ */
+function assertTaskAccess (task: TaskRecord | null, dependencies: HandlerDependencies): TaskRecord | null {
+  if (!task) return null
+  if (task.authSubject !== taskSubject(dependencies)) return null
+  return task
+}
+
+function relatedTaskMeta (taskId: string): Record<string, unknown> {
+  return { [RELATED_TASK_META_KEY]: { taskId } }
+}
+
+/**
+ * Should this `tools/call` run as a task?
+ *
+ * Combines the `task` request field with the tool's own `execution.taskSupport`
+ * declaration, which the spec layers on top of the server capability.
+ */
+export function resolveTaskAugmentation (
+  tool: MCPTool,
+  requested: boolean
+): { mode: 'task' | 'direct' } | { error: string } {
+  const support = (tool.definition as any).execution?.taskSupport ?? 'forbidden'
+
+  if (requested && support === 'forbidden') {
+    return { error: `Tool '${tool.definition.name}' does not support task-augmented execution` }
+  }
+  if (!requested && support === 'required') {
+    return { error: `Tool '${tool.definition.name}' requires task-augmented execution` }
+  }
+  return { mode: requested ? 'task' : 'direct' }
+}
+
+function newTaskRecord (method: string, ttl: number | undefined, subject: string | undefined): TaskRecord {
+  const now = new Date().toISOString()
+  const requested = ttl ?? DEFAULT_TASK_TTL
+  return {
+    taskId: randomUUID(),
+    status: 'working',
+    createdAt: now,
+    lastUpdatedAt: now,
+    // Receivers may override the requested ttl; we cap it
+    ttl: Math.min(requested, MAX_TASK_TTL),
+    pollInterval: DEFAULT_POLL_INTERVAL,
+    method,
+    authSubject: subject
+  }
+}
+
+async function handleTasksGet (
+  request: JSONRPCRequest,
+  dependencies: HandlerDependencies
+): Promise<JSONRPCResponse | JSONRPCError> {
+  const { taskStore } = dependencies
+  if (!taskStore) {
+    return createError(request.id, METHOD_NOT_FOUND, 'Tasks are not enabled on this server')
+  }
+
+  const taskId = (request.params as { taskId?: string } | undefined)?.taskId
+  if (!taskId) {
+    return createError(request.id, INVALID_PARAMS, 'Missing required parameter: taskId')
+  }
+
+  const task = assertTaskAccess(await taskStore.get(taskId), dependencies)
+  if (!task) {
+    return createError(request.id, INVALID_PARAMS, 'Failed to retrieve task: Task not found')
+  }
+
+  return createResponse(request.id, toWireTask(task))
+}
+
+async function handleTasksResult (
+  request: JSONRPCRequest,
+  dependencies: HandlerDependencies
+): Promise<JSONRPCResponse | JSONRPCError> {
+  const { taskStore, taskWaiters } = dependencies
+  if (!taskStore) {
+    return createError(request.id, METHOD_NOT_FOUND, 'Tasks are not enabled on this server')
+  }
+
+  const taskId = (request.params as { taskId?: string } | undefined)?.taskId
+  if (!taskId) {
+    return createError(request.id, INVALID_PARAMS, 'Missing required parameter: taskId')
+  }
+
+  let task = assertTaskAccess(await taskStore.get(taskId), dependencies)
+  if (!task) {
+    return createError(request.id, INVALID_PARAMS, 'Failed to retrieve task: Task not found')
+  }
+
+  // `tasks/result` blocks until the task is terminal
+  if (!isTerminal(task.status) && taskWaiters) {
+    const controller = new AbortController()
+    dependencies.request.raw.on('close', () => controller.abort())
+    try {
+      task = await taskWaiters.wait(taskId, controller.signal)
+    } catch {
+      return createError(request.id, INTERNAL_ERROR, 'Client disconnected while awaiting task result')
+    }
+  }
+
+  if (!isTerminal(task.status)) {
+    return createError(request.id, INTERNAL_ERROR, 'Task did not reach a terminal status')
+  }
+
+  if (!task.outcome) {
+    return createError(request.id, INTERNAL_ERROR, 'Task completed without recording a result')
+  }
+
+  // Return exactly what the underlying request would have returned, re-tagged
+  // with this request's id and the related-task metadata the spec requires.
+  if ('error' in task.outcome) {
+    return {
+      jsonrpc: JSONRPC_VERSION,
+      id: request.id,
+      error: task.outcome.error
+    }
+  }
+
+  return createResponse(request.id, {
+    ...task.outcome.result,
+    _meta: {
+      ...(task.outcome.result as any)._meta,
+      ...relatedTaskMeta(taskId)
+    }
+  })
+}
+
+async function handleTasksList (
+  request: JSONRPCRequest,
+  dependencies: HandlerDependencies
+): Promise<JSONRPCResponse | JSONRPCError> {
+  const { taskStore } = dependencies
+  if (!taskStore) {
+    return createError(request.id, METHOD_NOT_FOUND, 'Tasks are not enabled on this server')
+  }
+
+  const tasks = await taskStore.list(taskSubject(dependencies))
+  const result: ListTasksResult = {
+    tasks: tasks.map(toWireTask),
+    nextCursor: undefined
+  }
+  return createResponse(request.id, result)
+}
+
+async function handleTasksCancel (
+  request: JSONRPCRequest,
+  dependencies: HandlerDependencies
+): Promise<JSONRPCResponse | JSONRPCError> {
+  const { taskStore } = dependencies
+  if (!taskStore) {
+    return createError(request.id, METHOD_NOT_FOUND, 'Tasks are not enabled on this server')
+  }
+
+  const taskId = (request.params as { taskId?: string } | undefined)?.taskId
+  if (!taskId) {
+    return createError(request.id, INVALID_PARAMS, 'Missing required parameter: taskId')
+  }
+
+  const task = assertTaskAccess(await taskStore.get(taskId), dependencies)
+  if (!task) {
+    return createError(request.id, INVALID_PARAMS, 'Failed to retrieve task: Task not found')
+  }
+
+  if (isTerminal(task.status)) {
+    return createError(request.id, INVALID_PARAMS, `Cannot cancel task: already in terminal status '${task.status}'`)
+  }
+
+  const cancelled = await taskStore.updateStatus(taskId, 'cancelled', {
+    statusMessage: 'The task was cancelled by request.',
+    outcome: createError(request.id, INTERNAL_ERROR, 'Task was cancelled')
+  })
+
+  if (!cancelled) {
+    return createError(request.id, INVALID_PARAMS, 'Failed to retrieve task: Task not found')
+  }
+
+  dependencies.taskWaiters?.notify(cancelled)
+  await notifyTaskStatus(cancelled, dependencies)
+
+  return createResponse(request.id, toWireTask(cancelled))
+}
+
+/**
+ * Push a `notifications/tasks/status` to the session that owns the task.
+ * Optional per the spec — requestors must keep polling regardless — so a failure
+ * to deliver is logged and swallowed.
+ */
+async function notifyTaskStatus (task: TaskRecord, dependencies: HandlerDependencies): Promise<void> {
+  const { app, sessionId } = dependencies
+  if (!sessionId || typeof (app as any).mcpSendToSession !== 'function') return
+
+  try {
+    await (app as any).mcpSendToSession(sessionId, {
+      jsonrpc: JSONRPC_VERSION,
+      method: 'notifications/tasks/status',
+      params: toWireTask(task)
+    })
+  } catch (error) {
+    app.log.debug({ err: error, taskId: task.taskId }, 'Failed to deliver task status notification')
+  }
+}
+
+/**
+ * Run a tool call as a task: record it, answer immediately with a
+ * `CreateTaskResult`, and let execution finish in the background.
+ */
+async function runToolCallAsTask (
+  request: JSONRPCRequest,
+  ttl: number | undefined,
+  execute: () => Promise<JSONRPCResponse | JSONRPCError>,
+  dependencies: HandlerDependencies
+): Promise<JSONRPCResponse | JSONRPCError> {
+  const { taskStore, taskWaiters, app } = dependencies
+  if (!taskStore) {
+    return createError(request.id, METHOD_NOT_FOUND, 'Tasks are not enabled on this server')
+  }
+
+  const task = newTaskRecord('tools/call', ttl, taskSubject(dependencies))
+  await taskStore.create(task)
+
+  // Deliberately not awaited: the point of a task is to return control now.
+  const execution = (async () => {
+    let outcome: TaskRecord['outcome']
+    let status: 'completed' | 'failed' = 'completed'
+    let statusMessage: string | undefined
+
+    try {
+      const result = await execute()
+      outcome = result
+      // A tool result carrying isError counts as a failed task
+      if ('result' in result && (result.result as CallToolResult)?.isError === true) {
+        status = 'failed'
+        statusMessage = 'Tool execution reported an error'
+      } else if ('error' in result) {
+        status = 'failed'
+        statusMessage = result.error.message
+      }
+    } catch (error: any) {
+      status = 'failed'
+      statusMessage = `Tool execution failed: ${error?.message || error}`
+      outcome = createError(request.id, INTERNAL_ERROR, statusMessage)
+    }
+
+    try {
+      const updated = await taskStore.updateStatus(task.taskId, status, { statusMessage, outcome })
+      if (updated) {
+        taskWaiters?.notify(updated)
+        await notifyTaskStatus(updated, dependencies)
+      }
+    } catch (error) {
+      // The task was cancelled or expired while the tool was still running
+      app.log.debug({ err: error, taskId: task.taskId }, 'Could not record task outcome')
+    }
+  })()
+
+  // Nothing awaits `execution`; keep an explicit rejection guard so an
+  // unexpected throw can never become an unhandled rejection.
+  execution.catch((error) => {
+    app.log.error({ err: error, taskId: task.taskId }, 'Task execution failed unexpectedly')
+  })
+
+  const result: CreateTaskResult = { task: toWireTask(task) }
+  return createResponse(request.id, result)
+}
+
 async function handleResourcesSubscribe (
   request: JSONRPCRequest,
   sessionId: string | undefined,
@@ -550,7 +946,7 @@ export async function handleRequest (
   try {
     switch (request.method) {
       case 'initialize':
-        return handleInitialize(request, dependencies)
+        return await handleInitialize(request, sessionId, dependencies)
       case 'ping':
         return handlePing(request)
       case 'tools/list':
@@ -571,6 +967,14 @@ export async function handleRequest (
         return await handleResourcesUnsubscribe(request, sessionId, dependencies)
       case 'prompts/get':
         return await handlePromptsGet(request, sessionId, dependencies)
+      case 'tasks/get':
+        return await handleTasksGet(request, dependencies)
+      case 'tasks/result':
+        return await handleTasksResult(request, dependencies)
+      case 'tasks/list':
+        return await handleTasksList(request, dependencies)
+      case 'tasks/cancel':
+        return await handleTasksCancel(request, dependencies)
       default:
         return createError(request.id, METHOD_NOT_FOUND, `Method ${request.method} not found`)
     }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -607,6 +607,19 @@ const DEFAULT_TASK_TTL = 60_000
 const MAX_TASK_TTL = 3600_000
 
 /**
+ * Resolve the effective task ttl bounds from plugin options. Tasks are meant for
+ * long-running work, so a deployment whose tools outlive the 60s default can
+ * raise `taskDefaultTtlMs` / `taskMaxTtlMs` rather than have tasks expire before
+ * they finish (an expired task's `tasks/result` returns "not found").
+ */
+function taskTtlBounds (dependencies: HandlerDependencies): { defaultTtl: number, maxTtl: number } {
+  return {
+    defaultTtl: dependencies.opts.taskDefaultTtlMs ?? DEFAULT_TASK_TTL,
+    maxTtl: dependencies.opts.taskMaxTtlMs ?? MAX_TASK_TTL
+  }
+}
+
+/**
  * The authorization subject a task belongs to.
  *
  * When the deployment cannot identify requestors this is undefined, and tasks
@@ -615,6 +628,18 @@ const MAX_TASK_TTL = 3600_000
  */
 function taskSubject (dependencies: HandlerDependencies): string | undefined {
   return dependencies.authContext?.userId
+}
+
+/**
+ * Whether this deployment can tie a task to a requestor.
+ *
+ * Mirrors the gate in `index.ts` that decides whether to advertise
+ * `tasks.list`. Without authorization every task shares the undefined subject,
+ * so listing would hand every task's id to any caller — defeating the "random
+ * task id is the capability" model that protects `tasks/get|result|cancel`.
+ */
+function canIdentifyRequestors (dependencies: HandlerDependencies): boolean {
+  return dependencies.opts.authorization?.enabled === true
 }
 
 /**
@@ -653,16 +678,21 @@ export function resolveTaskAugmentation (
   return { mode: requested ? 'task' : 'direct' }
 }
 
-function newTaskRecord (method: string, ttl: number | undefined, subject: string | undefined): TaskRecord {
+function newTaskRecord (
+  method: string,
+  ttl: number | undefined,
+  subject: string | undefined,
+  bounds: { defaultTtl: number, maxTtl: number }
+): TaskRecord {
   const now = new Date().toISOString()
-  const requested = ttl ?? DEFAULT_TASK_TTL
+  const requested = ttl ?? bounds.defaultTtl
   return {
     taskId: randomUUID(),
     status: 'working',
     createdAt: now,
     lastUpdatedAt: now,
     // Receivers may override the requested ttl; we cap it
-    ttl: Math.min(requested, MAX_TASK_TTL),
+    ttl: Math.min(requested, bounds.maxTtl),
     pollInterval: DEFAULT_POLL_INTERVAL,
     method,
     authSubject: subject
@@ -833,6 +863,12 @@ async function handleTasksList (
     return createError(request.id, METHOD_NOT_FOUND, 'Tasks are not enabled on this server')
   }
 
+  // Never advertised without auth (see index.ts), so treat it as nonexistent
+  // rather than leaking every anonymous task's id to the caller.
+  if (!canIdentifyRequestors(dependencies)) {
+    return createError(request.id, METHOD_NOT_FOUND, 'Method tasks/list not found')
+  }
+
   const tasks = await taskStore.list(taskSubject(dependencies))
   const result: ListTasksResult = {
     tasks: tasks.map(toWireTask),
@@ -864,10 +900,18 @@ async function handleTasksCancel (
     return createError(request.id, INVALID_PARAMS, `Cannot cancel task: already in terminal status '${task.status}'`)
   }
 
-  const cancelled = await taskStore.updateStatus(taskId, 'cancelled', {
-    statusMessage: 'The task was cancelled by request.',
-    outcome: createError(request.id, INTERNAL_ERROR, 'Task was cancelled')
-  })
+  let cancelled: TaskRecord | null
+  try {
+    cancelled = await taskStore.updateStatus(taskId, 'cancelled', {
+      statusMessage: 'The task was cancelled by request.',
+      outcome: createError(request.id, INTERNAL_ERROR, 'Task was cancelled')
+    })
+  } catch {
+    // The task reached a terminal status between our check above and the write
+    // (it completed or was cancelled concurrently). The spec maps this to
+    // invalid params, not an internal error.
+    return createError(request.id, INVALID_PARAMS, 'Cannot cancel task: the task reached a terminal status before it could be cancelled')
+  }
 
   if (!cancelled) {
     return createError(request.id, INVALID_PARAMS, 'Failed to retrieve task: Task not found')
@@ -914,7 +958,7 @@ async function runToolCallAsTask (
     return createError(request.id, METHOD_NOT_FOUND, 'Tasks are not enabled on this server')
   }
 
-  const task = newTaskRecord('tools/call', ttl, taskSubject(dependencies))
+  const task = newTaskRecord('tools/call', ttl, taskSubject(dependencies), taskTtlBounds(dependencies))
   await taskStore.create(task)
 
   // Deliberately not awaited: the point of a task is to return control now.

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -25,8 +25,10 @@ import {
   SUPPORTED_PROTOCOL_VERSIONS,
   METHOD_NOT_FOUND,
   INTERNAL_ERROR,
-  INVALID_PARAMS
+  INVALID_PARAMS,
+  INVALID_REQUEST
 } from './schema.ts'
+import type { RequestId } from './schema.ts'
 
 import type { MCPTool, MCPResource, MCPPrompt, MCPPluginOptions, ResourceHandlers } from './types.ts'
 import type { SessionStore } from './stores/session-store.ts'
@@ -70,10 +72,12 @@ export function createResponse (id: string | number, result: any): JSONRPCRespon
   }
 }
 
-export function createError (id: string | number, code: number, message: string, data?: any): JSONRPCError {
+export function createError (id: string | number | null, code: number, message: string, data?: any): JSONRPCError {
   return {
     jsonrpc: JSONRPC_VERSION,
-    id,
+    // JSON-RPC requires an explicit null id when the request id is unknown
+    // (e.g. an unparseable batch); RequestId does not model null, so cast.
+    id: id as RequestId,
     error: { code, message, data }
   }
 }
@@ -644,12 +648,24 @@ function canIdentifyRequestors (dependencies: HandlerDependencies): boolean {
 
 /**
  * Enforce task isolation: a requestor may only touch its own tasks.
- * Returns an "invalid params" error rather than a distinct "forbidden" code so
- * that probing for task ids cannot distinguish existence from ownership.
+ * Returns null (surfaced as "invalid params") rather than a distinct "forbidden"
+ * code so that probing for task ids cannot distinguish existence from ownership.
  */
 function assertTaskAccess (task: TaskRecord | null, dependencies: HandlerDependencies): TaskRecord | null {
   if (!task) return null
-  if (task.authSubject !== taskSubject(dependencies)) return null
+
+  const subject = taskSubject(dependencies)
+
+  if (canIdentifyRequestors(dependencies)) {
+    // Auth on: a task is reachable only by the exact subject that owns it. A
+    // token without a `sub` claim identifies no one, so an undefined subject
+    // must never match another subject-less task via `undefined === undefined`.
+    if (subject === undefined || task.authSubject !== subject) return null
+    return task
+  }
+
+  // Auth off: no requestor can be identified, so the random task id is the
+  // capability and every (subject-less) task is reachable by whoever holds it.
   return task
 }
 
@@ -869,7 +885,15 @@ async function handleTasksList (
     return createError(request.id, METHOD_NOT_FOUND, 'Method tasks/list not found')
   }
 
-  const tasks = await taskStore.list(taskSubject(dependencies))
+  const subject = taskSubject(dependencies)
+  if (subject === undefined) {
+    // Auth is on but this token carries no `sub`, so it owns nothing we can
+    // identify. Listing the undefined-subject tasks would expose every other
+    // subject-less caller's tasks, so return an empty set instead.
+    return createResponse(request.id, { tasks: [], nextCursor: undefined } as ListTasksResult)
+  }
+
+  const tasks = await taskStore.list(subject)
   const result: ListTasksResult = {
     tasks: tasks.map(toWireTask),
     nextCursor: undefined
@@ -1140,6 +1164,12 @@ export async function processMessage (
   sessionId: string | undefined,
   dependencies: HandlerDependencies
 ): Promise<JSONRPCResponse | JSONRPCError | null> {
+  if (Array.isArray(message)) {
+    // JSON-RPC batching was removed in the 2025-06-18 revision. Refuse it with a
+    // proper protocol error rather than throwing, which the transport would
+    // otherwise surface as an opaque HTTP 500.
+    return createError(null, INVALID_REQUEST, 'Batch requests are not supported')
+  }
   if ('id' in message && 'method' in message) {
     return await handleRequest(message as JSONRPCRequest, sessionId, dependencies)
   } else if ('method' in message) {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -33,6 +33,12 @@ import type { SessionStore } from './stores/session-store.ts'
 import type { TaskStore, TaskRecord, TaskWaiters } from './stores/task-store.ts'
 import { isTerminal, toWireTask } from './stores/task-store.ts'
 import type { AuthorizationContext } from './types/auth-types.ts'
+import {
+  supportsTasks,
+  supportsSchemaDialect,
+  trimDefinitionToRevision,
+  capabilitiesForRevision
+} from './protocol-version.ts'
 import { validate, CallToolRequestSchema, ReadResourceRequestSchema, GetPromptRequestSchema, isTypeBoxSchema } from './validation/index.ts'
 import { sanitizeToolParams, assessToolSecurity, SECURITY_WARNINGS } from './security.ts'
 
@@ -52,6 +58,8 @@ type HandlerDependencies = {
   taskStore?: TaskStore
   taskWaiters?: TaskWaiters
   sessionId?: string
+  /** The revision this client negotiated; responses are shaped to match it */
+  protocolVersion?: string
 }
 
 export function createResponse (id: string | number, result: any): JSONRPCResponse {
@@ -114,7 +122,8 @@ async function handleInitialize (
 
   const result: InitializeResult = {
     protocolVersion,
-    capabilities,
+    // Never advertise a capability the agreed revision cannot express
+    capabilities: capabilitiesForRevision(capabilities, protocolVersion),
     serverInfo,
     instructions: opts.instructions
   }
@@ -133,24 +142,25 @@ function handlePing (request: JSONRPCRequest): JSONRPCResponse {
  */
 const JSON_SCHEMA_DIALECT = 'https://json-schema.org/draft/2020-12/schema'
 
-function withSchemaDialect<T> (schema: T): T {
+function withSchemaDialect<T> (schema: T, protocolVersion: string | undefined): T {
+  if (!supportsSchemaDialect(protocolVersion)) return schema
   if (!schema || typeof schema !== 'object') return schema
   if ('$schema' in (schema as Record<string, unknown>)) return schema
   return { $schema: JSON_SCHEMA_DIALECT, ...(schema as Record<string, unknown>) } as T
 }
 
 function handleToolsList (request: JSONRPCRequest, dependencies: HandlerDependencies): JSONRPCResponse {
-  const { tools } = dependencies
+  const { tools, protocolVersion } = dependencies
   const result: ListToolsResult = {
     tools: Array.from(tools.values()).map(t => {
-      const tool = t.definition
+      const tool = trimDefinitionToRevision(t.definition, protocolVersion)
       // TypeBox schemas are already JSON Schema compatible
       const serialized: typeof tool = {
         ...tool,
-        inputSchema: withSchemaDialect(tool.inputSchema)
+        inputSchema: withSchemaDialect(tool.inputSchema, protocolVersion)
       }
       if (serialized.outputSchema) {
-        serialized.outputSchema = withSchemaDialect(serialized.outputSchema)
+        serialized.outputSchema = withSchemaDialect(serialized.outputSchema, protocolVersion)
       }
       return serialized
     }),
@@ -166,23 +176,23 @@ function isTemplateUri (uri: string): boolean {
 }
 
 function handleResourcesList (request: JSONRPCRequest, dependencies: HandlerDependencies): JSONRPCResponse {
-  const { resources } = dependencies
+  const { resources, protocolVersion } = dependencies
   const result: ListResourcesResult = {
     resources: Array.from(resources.values())
       .filter(r => !isTemplateUri(r.definition.uri))
-      .map(r => r.definition),
+      .map(r => trimDefinitionToRevision(r.definition, protocolVersion)),
     nextCursor: undefined
   }
   return createResponse(request.id, result)
 }
 
 function handleResourceTemplatesList (request: JSONRPCRequest, dependencies: HandlerDependencies): JSONRPCResponse {
-  const { resources } = dependencies
+  const { resources, protocolVersion } = dependencies
   const result: ListResourceTemplatesResult = {
     resourceTemplates: Array.from(resources.values())
       .filter(r => isTemplateUri(r.definition.uri))
       .map(r => {
-        const { uri, ...rest } = r.definition
+        const { uri, ...rest } = trimDefinitionToRevision(r.definition, protocolVersion)
         return { ...rest, uriTemplate: uri }
       }),
     nextCursor: undefined
@@ -191,9 +201,9 @@ function handleResourceTemplatesList (request: JSONRPCRequest, dependencies: Han
 }
 
 function handlePromptsList (request: JSONRPCRequest, dependencies: HandlerDependencies): JSONRPCResponse {
-  const { prompts } = dependencies
+  const { prompts, protocolVersion } = dependencies
   const result: ListPromptsResult = {
-    prompts: Array.from(prompts.values()).map(p => p.definition),
+    prompts: Array.from(prompts.values()).map(p => trimDefinitionToRevision(p.definition, protocolVersion)),
     nextCursor: undefined
   }
   return createResponse(request.id, result)
@@ -224,7 +234,11 @@ async function handleToolsCall (
 
   // Decide up front whether this call runs as a task, so the rest of the
   // handler can stay unaware of it.
-  const taskParams = (request.params as { task?: { ttl?: number } } | undefined)?.task
+  // A client on an older revision cannot have meant `task`, because we never
+  // declared the capability to it. The spec says to ignore it in that case.
+  const taskParams = supportsTasks(dependencies.protocolVersion)
+    ? (request.params as { task?: { ttl?: number } } | undefined)?.task
+    : undefined
   const augmentation = resolveTaskAugmentation(tool, taskParams !== undefined)
   if ('error' in augmentation) {
     return createError(request.id, METHOD_NOT_FOUND, augmentation.error)
@@ -968,12 +982,17 @@ export async function handleRequest (
       case 'prompts/get':
         return await handlePromptsGet(request, sessionId, dependencies)
       case 'tasks/get':
-        return await handleTasksGet(request, dependencies)
       case 'tasks/result':
-        return await handleTasksResult(request, dependencies)
       case 'tasks/list':
-        return await handleTasksList(request, dependencies)
       case 'tasks/cancel':
+        // Tasks arrived in 2025-11-25; to an older client these methods simply
+        // do not exist, and we never advertised them.
+        if (!supportsTasks(dependencies.protocolVersion)) {
+          return createError(request.id, METHOD_NOT_FOUND, `Method ${request.method} not found`)
+        }
+        if (request.method === 'tasks/get') return await handleTasksGet(request, dependencies)
+        if (request.method === 'tasks/result') return await handleTasksResult(request, dependencies)
+        if (request.method === 'tasks/list') return await handleTasksList(request, dependencies)
         return await handleTasksCancel(request, dependencies)
       default:
         return createError(request.id, METHOD_NOT_FOUND, `Method ${request.method} not found`)

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -691,11 +691,82 @@ async function handleTasksGet (
   return createResponse(request.id, toWireTask(task))
 }
 
+/**
+ * Suspend for `ms`, or reject as soon as `signal` aborts.
+ */
+function delay (ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error('aborted'))
+      return
+    }
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(new Error('aborted'))
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    if (typeof timer.unref === 'function') timer.unref()
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * Block until the task reaches a terminal status, or throw when `signal` aborts.
+ *
+ * Two mechanisms run together:
+ *  - an in-process waiter that fires the instant *this* instance completes the
+ *    task, giving zero-latency wake-ups for single-instance and same-instance
+ *    cases; and
+ *  - bounded polling of the shared task store, which is what makes this correct
+ *    across instances: with a Redis-backed store the task may complete on a
+ *    different instance, whose `notify()` this process never sees, so polling is
+ *    the only mechanism guaranteed to observe the terminal state.
+ *
+ * Returns null if the task disappears (expires or is deleted) while waiting.
+ */
+async function awaitTaskTerminal (
+  taskId: string,
+  initial: TaskRecord,
+  dependencies: HandlerDependencies,
+  signal: AbortSignal
+): Promise<TaskRecord | null> {
+  const { taskStore, taskWaiters } = dependencies
+  if (!taskStore) return initial
+
+  // A single waiter for the whole call. Resolves to a terminal task when this
+  // instance completes it, or to null when aborted — caught here so that losing
+  // the race below can never surface as an unhandled rejection.
+  const accelerator: Promise<TaskRecord | null> = taskWaiters
+    ? taskWaiters.wait(taskId, signal).then(task => task).catch(() => null)
+    : new Promise<TaskRecord | null>(() => {})
+
+  let task: TaskRecord | null = initial
+  while (task && !isTerminal(task.status)) {
+    const pollDelay = task.pollInterval ?? DEFAULT_POLL_INTERVAL
+    const winner = await Promise.race([
+      accelerator,
+      delay(pollDelay, signal).then(() => null)
+    ])
+
+    if (winner && isTerminal(winner.status)) {
+      return winner
+    }
+    // The poll timer elapsed (or the accelerator aborted); the shared store is
+    // the source of truth, so re-read it before deciding whether to loop again.
+    task = await taskStore.get(taskId)
+  }
+
+  return task
+}
+
 async function handleTasksResult (
   request: JSONRPCRequest,
   dependencies: HandlerDependencies
 ): Promise<JSONRPCResponse | JSONRPCError> {
-  const { taskStore, taskWaiters } = dependencies
+  const { taskStore } = dependencies
   if (!taskStore) {
     return createError(request.id, METHOD_NOT_FOUND, 'Tasks are not enabled on this server')
   }
@@ -710,12 +781,17 @@ async function handleTasksResult (
     return createError(request.id, INVALID_PARAMS, 'Failed to retrieve task: Task not found')
   }
 
-  // `tasks/result` blocks until the task is terminal
-  if (!isTerminal(task.status) && taskWaiters) {
+  // `tasks/result` blocks until the task is terminal. Works across instances:
+  // see awaitTaskTerminal.
+  if (!isTerminal(task.status)) {
     const controller = new AbortController()
     dependencies.request.raw.on('close', () => controller.abort())
     try {
-      task = await taskWaiters.wait(taskId, controller.signal)
+      const settled = await awaitTaskTerminal(taskId, task, dependencies, controller.signal)
+      if (!settled) {
+        return createError(request.id, INVALID_PARAMS, 'Failed to retrieve task: Task not found')
+      }
+      task = settled
     } catch {
       return createError(request.id, INTERNAL_ERROR, 'Client disconnected while awaiting task result')
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,10 @@ import { MemorySessionStore } from './stores/memory-session-store.ts'
 import { MemoryMessageBroker } from './brokers/memory-message-broker.ts'
 import { RedisSessionStore } from './stores/redis-session-store.ts'
 import { RedisMessageBroker } from './brokers/redis-message-broker.ts'
+import type { TaskStore } from './stores/task-store.ts'
+import { TaskWaiters } from './stores/task-store.ts'
+import { MemoryTaskStore } from './stores/memory-task-store.ts'
+import { RedisTaskStore } from './stores/redis-task-store.ts'
 import type { MCPPluginOptions, MCPTool, MCPResource, MCPPrompt, ResourceHandlers } from './types.ts'
 import pubsubDecorators from './decorators/pubsub.ts'
 import metaDecorators from './decorators/meta.ts'
@@ -22,6 +26,8 @@ import type {
   JSONRPCMessage,
   JSONRPCRequest,
   JSONRPCResponse,
+  JSONRPCResultResponse,
+  JSONRPCErrorResponse,
   JSONRPCError,
   JSONRPCNotification,
   ServerCapabilities,
@@ -29,9 +35,16 @@ import type {
   Tool,
   Resource,
   Prompt,
+  Icon,
   CallToolResult,
   ReadResourceResult,
-  GetPromptResult
+  GetPromptResult,
+  Task,
+  TaskStatus,
+  CreateTaskResult,
+  ListTasksResult,
+  ElicitRequestFormParams,
+  ElicitRequestURLParams
 } from './schema.ts'
 
 const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOptions) {
@@ -47,6 +60,7 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
   }
 
   const enableSSE = opts.enableSSE ?? false
+  const enableTasks = opts.enableTasks ?? false
   const tools = new Map<string, MCPTool>()
   const resources = new Map<string, MCPResource>()
   const prompts = new Map<string, MCPPrompt>()
@@ -57,15 +71,41 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
   let messageBroker: MessageBroker
   let redis: Redis | null = null
 
+  let taskStore: TaskStore | undefined
+
   if (opts.redis) {
     // Redis implementations for horizontal scaling
     redis = new Redis(opts.redis)
     sessionStore = new RedisSessionStore({ redis, maxMessages: 100 })
     messageBroker = new RedisMessageBroker(redis)
+    if (enableTasks) {
+      taskStore = new RedisTaskStore({ redis })
+    }
   } else {
     // Memory implementations for single-instance deployment
     sessionStore = new MemorySessionStore(100)
     messageBroker = new MemoryMessageBroker()
+    if (enableTasks) {
+      taskStore = new MemoryTaskStore()
+    }
+  }
+
+  // Waiters are process-local by design: only the instance serving a given
+  // tasks/result request needs to be woken when that task finishes.
+  const taskWaiters = new TaskWaiters()
+
+  if (enableTasks) {
+    // Advertise which task operations we support. `tasks/list` is only offered
+    // when authorization is on, because without an identifiable requestor it
+    // would expose every task's metadata to anyone who can reach the server.
+    const canIdentifyRequestors = opts.authorization?.enabled === true
+    capabilities.tasks = {
+      ...(canIdentifyRequestors ? { list: {} } : {}),
+      cancel: {},
+      requests: {
+        tools: { call: {} }
+      }
+    }
   }
 
   // Local stream management per server instance
@@ -124,7 +164,9 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
     resourceHandlers,
     sessionStore,
     messageBroker,
-    localStreams
+    localStreams,
+    taskStore,
+    taskWaiters
   })
 
   // Add close hook to clean up Redis connections and authorization components
@@ -216,6 +258,8 @@ export type {
   JSONRPCMessage,
   JSONRPCRequest,
   JSONRPCResponse,
+  JSONRPCResultResponse,
+  JSONRPCErrorResponse,
   JSONRPCError,
   JSONRPCNotification,
   ServerCapabilities,
@@ -223,7 +267,28 @@ export type {
   Tool,
   Resource,
   Prompt,
+  Icon,
   CallToolResult,
   ReadResourceResult,
-  GetPromptResult
+  GetPromptResult,
+  Task,
+  TaskStatus,
+  CreateTaskResult,
+  ListTasksResult,
+  ElicitRequestFormParams,
+  ElicitRequestURLParams
 }
+
+// Protocol constants, so consumers can negotiate and branch on the revision
+export {
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  DEFAULT_NEGOTIATED_PROTOCOL_VERSION,
+  JSONRPC_VERSION,
+  URL_ELICITATION_REQUIRED
+} from './schema.ts'
+
+// Task storage, for callers that want to supply or inspect a backend
+export type { TaskStore, TaskRecord, TaskOutcome } from './stores/task-store.ts'
+export { MemoryTaskStore } from './stores/memory-task-store.ts'
+export { RedisTaskStore } from './stores/redis-task-store.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
     sessionStore = new RedisSessionStore({ redis, maxMessages: 100 })
     messageBroker = new RedisMessageBroker(redis)
     if (enableTasks) {
-      taskStore = new RedisTaskStore({ redis })
+      taskStore = new RedisTaskStore({ redis, defaultTtlMs: opts.taskDefaultTtlMs })
     }
   } else {
     // Memory implementations for single-instance deployment

--- a/src/protocol-version.ts
+++ b/src/protocol-version.ts
@@ -1,0 +1,76 @@
+/**
+ * Helpers for behaving according to the revision a client actually negotiated,
+ * rather than always answering with the newest one we implement.
+ *
+ * Protocol versions are `YYYY-MM-DD` strings, so ordering them is a plain
+ * lexicographic comparison.
+ */
+
+/** The revision that introduced tasks, icons, URL elicitation and the JSON Schema dialect */
+export const REVISION_2025_11_25 = '2025-11-25'
+
+/**
+ * True when `version` is `minimum` or newer. An absent version is treated as
+ * older than everything, so features stay off unless we positively know better.
+ */
+export function atLeast (version: string | undefined, minimum: string): boolean {
+  if (!version) return false
+  return version >= minimum
+}
+
+/** Task-augmented execution and the `tasks/*` methods (SEP-1686) */
+export function supportsTasks (version: string | undefined): boolean {
+  return atLeast(version, REVISION_2025_11_25)
+}
+
+/** `icons` metadata on tools, resources, resource templates and prompts (SEP-973) */
+export function supportsIcons (version: string | undefined): boolean {
+  return atLeast(version, REVISION_2025_11_25)
+}
+
+/** `execution.taskSupport` on tool definitions (SEP-1686) */
+export function supportsToolExecutionMetadata (version: string | undefined): boolean {
+  return atLeast(version, REVISION_2025_11_25)
+}
+
+/** Declaring JSON Schema 2020-12 as the dialect of published schemas (SEP-1613) */
+export function supportsSchemaDialect (version: string | undefined): boolean {
+  return atLeast(version, REVISION_2025_11_25)
+}
+
+/** URL mode elicitation (SEP-1036) */
+export function supportsUrlElicitation (version: string | undefined): boolean {
+  return atLeast(version, REVISION_2025_11_25)
+}
+
+/**
+ * Remove definition fields a revision does not define, so a client never sees a
+ * field the revision it negotiated has no meaning for.
+ */
+export function trimDefinitionToRevision<T extends Record<string, any>> (definition: T, version: string | undefined): T {
+  if (supportsIcons(version) && supportsToolExecutionMetadata(version)) {
+    return definition
+  }
+
+  const trimmed: Record<string, any> = { ...definition }
+  if (!supportsIcons(version)) {
+    delete trimmed.icons
+  }
+  if (!supportsToolExecutionMetadata(version)) {
+    delete trimmed.execution
+  }
+  return trimmed as T
+}
+
+/**
+ * Drop capabilities that postdate the negotiated revision, so we never advertise
+ * something the client's revision cannot express.
+ */
+export function capabilitiesForRevision<T extends Record<string, any>> (capabilities: T, version: string | undefined): T {
+  if (supportsTasks(version) || capabilities.tasks === undefined) {
+    return capabilities
+  }
+
+  const { tasks, ...rest } = capabilities
+  return rest as T
+}

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -2,9 +2,11 @@ import { randomUUID } from 'crypto'
 import type { FastifyRequest, FastifyReply, FastifyPluginAsync } from 'fastify'
 import fp from 'fastify-plugin'
 import type { JSONRPCMessage } from '../schema.ts'
-import { JSONRPC_VERSION, INTERNAL_ERROR } from '../schema.ts'
+import { JSONRPC_VERSION, INTERNAL_ERROR, SUPPORTED_PROTOCOL_VERSIONS, DEFAULT_NEGOTIATED_PROTOCOL_VERSION } from '../schema.ts'
+import { isOriginAllowed } from '../security.ts'
 import type { MCPPluginOptions, MCPTool, MCPResource, MCPPrompt, ResourceHandlers } from '../types.ts'
 import type { SessionStore, SessionMetadata } from '../stores/session-store.ts'
+import type { TaskStore, TaskWaiters } from '../stores/task-store.ts'
 import type { MessageBroker } from '../brokers/message-broker.ts'
 import type { AuthorizationContext } from '../types/auth-types.ts'
 import { processMessage } from '../handlers.ts'
@@ -21,10 +23,55 @@ interface MCPPubSubRoutesOptions {
   sessionStore: SessionStore
   messageBroker: MessageBroker
   localStreams: Map<string, Set<any>>
+  taskStore?: TaskStore
+  taskWaiters?: TaskWaiters
 }
 
 const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async (app, options) => {
-  const { enableSSE, opts, capabilities, serverInfo, tools, resources, prompts, resourceHandlers, sessionStore, messageBroker, localStreams } = options
+  const { enableSSE, opts, capabilities, serverInfo, tools, resources, prompts, resourceHandlers, sessionStore, messageBroker, localStreams, taskStore, taskWaiters } = options
+
+  const allowedOrigins = opts.allowedOrigins
+
+  if (allowedOrigins === undefined) {
+    app.log.warn('MCP: no allowedOrigins configured, Origin validation is disabled. Set allowedOrigins to protect browser clients against DNS rebinding.')
+  }
+
+  // Guard against DNS rebinding: reject browser origins we do not trust.
+  // The 2025-11-25 revision requires 403 here, not 400.
+  async function validateOrigin (request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const origin = request.headers.origin as string | undefined
+    if (!isOriginAllowed(origin, allowedOrigins)) {
+      request.log.warn({ origin }, 'Rejected MCP request with disallowed Origin')
+      return reply.code(403).type('application/json').send({
+        error: 'Forbidden: Origin not allowed'
+      })
+    }
+  }
+
+  // Clients must echo the negotiated protocol version on every request after
+  // `initialize`. An absent header means 2025-03-26, which predates the header.
+  async function validateProtocolVersionHeader (request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const header = request.headers['mcp-protocol-version']
+    if (header === undefined) {
+      ;(request as any).mcpProtocolVersion = DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+      return
+    }
+
+    const version = Array.isArray(header) ? header[0] : header
+    if (!(SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(version)) {
+      request.log.warn({ version }, 'Rejected MCP request with unsupported MCP-Protocol-Version header')
+      return reply.code(400).type('application/json').send({
+        error: `Bad Request: unsupported MCP-Protocol-Version '${version}'`,
+        supported: SUPPORTED_PROTOCOL_VERSIONS
+      })
+    }
+
+    ;(request as any).mcpProtocolVersion = version
+  }
+
+  // Scoped to the /mcp routes only: this plugin is not encapsulated, so an
+  // app-level hook would also cover the OAuth and well-known routes.
+  const mcpOnRequest = [validateOrigin, validateProtocolVersionHeader]
 
   async function createSSESession (): Promise<SessionMetadata> {
     const sessionId = randomUUID()
@@ -132,7 +179,7 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
     }
   }
 
-  app.post('/mcp', async (request: FastifyRequest, reply: FastifyReply) => {
+  app.post('/mcp', { onRequest: mcpOnRequest }, async (request: FastifyRequest, reply: FastifyReply) => {
     try {
       const message = request.body as JSONRPCMessage
       let sessionId = request.headers['mcp-session-id'] as string
@@ -189,7 +236,11 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
         resourceHandlers,
         request,
         reply,
-        authContext
+        authContext,
+        sessionStore,
+        taskStore,
+        taskWaiters,
+        sessionId
       })
       if (response) {
         return response
@@ -210,7 +261,7 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
   })
 
   // GET endpoint for server-initiated communication via SSE
-  app.get('/mcp', async (request: FastifyRequest, reply: FastifyReply) => {
+  app.get('/mcp', { onRequest: mcpOnRequest }, async (request: FastifyRequest, reply: FastifyReply) => {
     if (!enableSSE) {
       reply.type('application/json').code(405).send({ error: 'Method Not Allowed: SSE not enabled' })
       return
@@ -300,6 +351,27 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
         }
       })
 
+      // SEP-1699: servers may end an SSE stream whenever they like, turning the
+      // stream into a polling channel. The client reconnects with Last-Event-ID
+      // on GET and we replay whatever it missed, so closing here loses nothing.
+      let maxDurationTimer: NodeJS.Timeout | undefined
+      if (opts.sseMaxConnectionMs) {
+        maxDurationTimer = setTimeout(() => {
+          app.log.info({
+            sessionId: session.id,
+            afterMs: opts.sseMaxConnectionMs
+          }, 'Closing SSE stream to let the client poll; it may resume with Last-Event-ID')
+          try {
+            reply.raw.end()
+          } catch {
+            // already gone
+          }
+        }, opts.sseMaxConnectionMs)
+        maxDurationTimer.unref()
+
+        reply.raw.on('close', () => clearTimeout(maxDurationTimer))
+      }
+
       // Send initial heartbeat
       reply.raw.write(': heartbeat\n\n')
 
@@ -331,7 +403,7 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
 
   // DELETE endpoint for explicit session termination (MCP spec)
   if (enableSSE) {
-    app.delete('/mcp', async (request: FastifyRequest, reply: FastifyReply) => {
+    app.delete('/mcp', { onRequest: mcpOnRequest }, async (request: FastifyRequest, reply: FastifyReply) => {
       const sessionId = request.headers['mcp-session-id'] as string
       if (!sessionId) {
         reply.code(400).send({ error: 'Missing Mcp-Session-Id header' })

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -69,9 +69,54 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
     ;(request as any).mcpProtocolVersion = version
   }
 
+  /**
+   * `initialize` is the negotiation itself, so it is exempt from having to match
+   * a version agreed earlier — a client is allowed to re-negotiate on a session.
+   */
+  function isInitializeRequest (body: unknown): boolean {
+    if (Array.isArray(body)) {
+      return body.some(entry => (entry as { method?: string })?.method === 'initialize')
+    }
+    return (body as { method?: string } | undefined)?.method === 'initialize'
+  }
+
+  /**
+   * Reconcile the header against what the session actually negotiated.
+   *
+   * The session is authoritative: a client that agreed on 2025-03-26 must not be
+   * able to opt into newer behaviour just by sending a newer header. Runs as a
+   * preHandler because deciding whether this is an `initialize` needs the body.
+   */
+  async function reconcileProtocolVersion (request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const sessionId = request.headers['mcp-session-id'] as string | undefined
+    if (!sessionId) return
+
+    const session = await sessionStore.get(sessionId)
+    const negotiated = session?.protocolVersion
+    if (!negotiated) return
+
+    if (isInitializeRequest(request.body)) return
+
+    const header = request.headers['mcp-protocol-version']
+    if (header !== undefined) {
+      const sent = Array.isArray(header) ? header[0] : header
+      if (sent !== negotiated) {
+        request.log.warn({ sent, negotiated, sessionId }, 'MCP-Protocol-Version does not match the version negotiated for this session')
+        return reply.code(400).type('application/json').send({
+          error: `Bad Request: MCP-Protocol-Version '${sent}' does not match the version negotiated for this session`,
+          negotiated
+        })
+      }
+    }
+
+    // We know what was agreed, so prefer it over the header-derived default
+    ;(request as any).mcpProtocolVersion = negotiated
+  }
+
   // Scoped to the /mcp routes only: this plugin is not encapsulated, so an
   // app-level hook would also cover the OAuth and well-known routes.
   const mcpOnRequest = [validateOrigin, validateProtocolVersionHeader]
+  const mcpPreHandler = [reconcileProtocolVersion]
 
   async function createSSESession (): Promise<SessionMetadata> {
     const sessionId = randomUUID()
@@ -179,7 +224,7 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
     }
   }
 
-  app.post('/mcp', { onRequest: mcpOnRequest }, async (request: FastifyRequest, reply: FastifyReply) => {
+  app.post('/mcp', { onRequest: mcpOnRequest, preHandler: mcpPreHandler }, async (request: FastifyRequest, reply: FastifyReply) => {
     try {
       const message = request.body as JSONRPCMessage
       let sessionId = request.headers['mcp-session-id'] as string
@@ -240,7 +285,8 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
         sessionStore,
         taskStore,
         taskWaiters,
-        sessionId
+        sessionId,
+        protocolVersion: (request as any).mcpProtocolVersion ?? DEFAULT_NEGOTIATED_PROTOCOL_VERSION
       })
       if (response) {
         return response
@@ -261,7 +307,7 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
   })
 
   // GET endpoint for server-initiated communication via SSE
-  app.get('/mcp', { onRequest: mcpOnRequest }, async (request: FastifyRequest, reply: FastifyReply) => {
+  app.get('/mcp', { onRequest: mcpOnRequest, preHandler: mcpPreHandler }, async (request: FastifyRequest, reply: FastifyReply) => {
     if (!enableSSE) {
       reply.type('application/json').code(405).send({ error: 'Method Not Allowed: SSE not enabled' })
       return
@@ -403,7 +449,7 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
 
   // DELETE endpoint for explicit session termination (MCP spec)
   if (enableSSE) {
-    app.delete('/mcp', { onRequest: mcpOnRequest }, async (request: FastifyRequest, reply: FastifyReply) => {
+    app.delete('/mcp', { onRequest: mcpOnRequest, preHandler: mcpPreHandler }, async (request: FastifyRequest, reply: FastifyReply) => {
       const sessionId = request.headers['mcp-session-id'] as string
       if (!sessionId) {
         reply.code(400).send({ error: 'Missing Mcp-Session-Id header' })

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -26,74 +26,159 @@ SOFTWARE.
 /**
  * Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.
  *
- * @internal
+ * @category JSON-RPC
  */
 export type JSONRPCMessage =
-  | JSONRPCRequest
-  | JSONRPCNotification
-  | JSONRPCResponse
-  | JSONRPCError
+  JSONRPCRequest | JSONRPCNotification | JSONRPCResponse
 
 /** @internal */
-export const LATEST_PROTOCOL_VERSION = '2025-06-18'
+export const LATEST_PROTOCOL_VERSION = '2025-11-25'
 /** @internal */
 export const JSONRPC_VERSION = '2.0'
 
 /**
+ * All protocol revisions this server can speak, newest first. Used during the
+ * `initialize` handshake: if the client asks for one of these we echo it back,
+ * otherwise we answer with {@link LATEST_PROTOCOL_VERSION} and let the client
+ * decide whether it can proceed.
+ *
+ * @internal
+ */
+export const SUPPORTED_PROTOCOL_VERSIONS = [
+  '2025-11-25',
+  '2025-06-18',
+  '2025-03-26',
+  '2024-11-05'
+] as const
+
+/**
+ * Protocol version assumed for HTTP requests that omit the `MCP-Protocol-Version`
+ * header, per the 2025-06-18 transport specification.
+ *
+ * @internal
+ */
+export const DEFAULT_NEGOTIATED_PROTOCOL_VERSION = '2025-03-26'
+
+/**
+ * Pre-2025-11-25 name for {@link JSONRPCErrorResponse}, kept so existing consumers
+ * of this package keep compiling.
+ *
+ * @deprecated use {@link JSONRPCErrorResponse}
+ */
+export type JSONRPCError = JSONRPCErrorResponse
+
+/**
  * A progress token, used to associate progress notifications with the original request.
+ *
+ * @category Common Types
  */
 export type ProgressToken = string | number
 
 /**
  * An opaque token used to represent a cursor for pagination.
+ *
+ * @category Common Types
  */
 export type Cursor = string
+
+/**
+ * Common params for any task-augmented request.
+ *
+ * @internal
+ */
+export interface TaskAugmentedRequestParams extends RequestParams {
+  /**
+   * If specified, the caller is requesting task-augmented execution for this request.
+   * The request will return a CreateTaskResult immediately, and the actual result can be
+   * retrieved later via tasks/result.
+   *
+   * Task augmentation is subject to capability negotiation - receivers MUST declare support
+   * for task augmentation of specific request types in their capabilities.
+   */
+  task?: TaskMetadata;
+}
+/**
+ * Common params for any request.
+ *
+ * @internal
+ */
+export interface RequestParams {
+  /**
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+   */
+  _meta?: {
+    /**
+     * If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
+     */
+    progressToken?: ProgressToken;
+    [key: string]: unknown;
+  };
+}
 
 /** @internal */
 export interface Request {
   method: string;
-  params?: {
-    /**
-     * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
-     */
-    _meta?: {
-      /**
-       * If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
-       */
-      progressToken?: ProgressToken;
-      [key: string]: unknown;
-    };
-    [key: string]: unknown;
-  };
+  // Allow unofficial extensions of `Request.params` without impacting `RequestParams`.
+
+  params?: { [key: string]: any };
+}
+
+/** @internal */
+export interface NotificationParams {
+  /**
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /** @internal */
 export interface Notification {
   method: string;
-  params?: {
-    /**
-     * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
-     */
-    _meta?: { [key: string]: unknown };
-    [key: string]: unknown;
-  };
+  // Allow unofficial extensions of `Notification.params` without impacting `NotificationParams`.
+
+  params?: { [key: string]: any };
 }
 
+/**
+ * @category Common Types
+ */
 export interface Result {
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
   [key: string]: unknown;
 }
 
 /**
+ * @category Common Types
+ */
+export interface Error {
+  /**
+   * The error type that occurred.
+   */
+  code: number;
+  /**
+   * A short description of the error. The message SHOULD be limited to a concise single sentence.
+   */
+  message: string;
+  /**
+   * Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.).
+   */
+  data?: unknown;
+}
+
+/**
  * A uniquely identifying ID for a request in JSON-RPC.
+ *
+ * @category Common Types
  */
 export type RequestId = string | number
 
 /**
  * A request that expects a response.
+ *
+ * @category JSON-RPC
  */
 export interface JSONRPCRequest extends Request {
   jsonrpc: typeof JSONRPC_VERSION;
@@ -102,6 +187,8 @@ export interface JSONRPCRequest extends Request {
 
 /**
  * A notification which does not expect a response.
+ *
+ * @category JSON-RPC
  */
 export interface JSONRPCNotification extends Notification {
   jsonrpc: typeof JSONRPC_VERSION;
@@ -109,54 +196,92 @@ export interface JSONRPCNotification extends Notification {
 
 /**
  * A successful (non-error) response to a request.
+ *
+ * @category JSON-RPC
  */
-export interface JSONRPCResponse {
+export interface JSONRPCResultResponse {
   jsonrpc: typeof JSONRPC_VERSION;
   id: RequestId;
   result: Result;
 }
 
-// Standard JSON-RPC error codes
-/** @internal */
-export const PARSE_ERROR = -32700
-/** @internal */
-export const INVALID_REQUEST = -32600
-/** @internal */
-export const METHOD_NOT_FOUND = -32601
-/** @internal */
-export const INVALID_PARAMS = -32602
-/** @internal */
-export const INTERNAL_ERROR = -32603
-
 /**
  * A response to a request that indicates an error occurred.
+ *
+ * @category JSON-RPC
  */
-export interface JSONRPCError {
+export interface JSONRPCErrorResponse {
   jsonrpc: typeof JSONRPC_VERSION;
-  id: RequestId;
-  error: {
-    /**
-     * The error type that occurred.
-     */
-    code: number;
-    /**
-     * A short description of the error. The message SHOULD be limited to a concise single sentence.
-     */
-    message: string;
-    /**
-     * Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.).
-     */
-    data?: unknown;
+  id?: RequestId;
+  error: Error;
+}
+
+/**
+ * A response to a request, containing either the result or error.
+ *
+ * @category JSON-RPC
+ */
+export type JSONRPCResponse = JSONRPCResultResponse | JSONRPCErrorResponse
+
+// Standard JSON-RPC error codes
+export const PARSE_ERROR = -32700
+export const INVALID_REQUEST = -32600
+export const METHOD_NOT_FOUND = -32601
+export const INVALID_PARAMS = -32602
+export const INTERNAL_ERROR = -32603
+
+// Implementation-specific JSON-RPC error codes [-32000, -32099]
+/** @internal */
+export const URL_ELICITATION_REQUIRED = -32042
+
+/**
+ * An error response that indicates that the server requires the client to provide additional information via an elicitation request.
+ *
+ * @internal
+ */
+export interface URLElicitationRequiredError extends Omit<
+  JSONRPCErrorResponse,
+  'error'
+> {
+  error: Error & {
+    code: typeof URL_ELICITATION_REQUIRED;
+    data: {
+      elicitations: ElicitRequestURLParams[];
+      [key: string]: unknown;
+    };
   };
 }
 
 /* Empty result */
 /**
  * A response that indicates success but carries no data.
+ *
+ * @category Common Types
  */
 export type EmptyResult = Result
 
 /* Cancellation */
+/**
+ * Parameters for a `notifications/cancelled` notification.
+ *
+ * @category `notifications/cancelled`
+ */
+export interface CancelledNotificationParams extends NotificationParams {
+  /**
+   * The ID of the request to cancel.
+   *
+   * This MUST correspond to the ID of a request previously issued in the same direction.
+   * This MUST be provided for cancelling non-task requests.
+   * This MUST NOT be used for cancelling tasks (use the `tasks/cancel` request instead).
+   */
+  requestId?: RequestId;
+
+  /**
+   * An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.
+   */
+  reason?: string;
+}
+
 /**
  * This notification can be sent by either side to indicate that it is cancelling a previously-issued request.
  *
@@ -166,47 +291,44 @@ export type EmptyResult = Result
  *
  * A client MUST NOT attempt to cancel its `initialize` request.
  *
- * @category notifications/cancelled
+ * For task cancellation, use the `tasks/cancel` request instead of this notification.
+ *
+ * @category `notifications/cancelled`
  */
-export interface CancelledNotification extends Notification {
+export interface CancelledNotification extends JSONRPCNotification {
   method: 'notifications/cancelled';
-  params: {
-    /**
-     * The ID of the request to cancel.
-     *
-     * This MUST correspond to the ID of a request previously issued in the same direction.
-     */
-    requestId: RequestId;
-
-    /**
-     * An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.
-     */
-    reason?: string;
-  };
+  params: CancelledNotificationParams;
 }
 
 /* Initialization */
 /**
+ * Parameters for an `initialize` request.
+ *
+ * @category `initialize`
+ */
+export interface InitializeRequestParams extends RequestParams {
+  /**
+   * The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.
+   */
+  protocolVersion: string;
+  capabilities: ClientCapabilities;
+  clientInfo: Implementation;
+}
+
+/**
  * This request is sent from the client to the server when it first connects, asking it to begin initialization.
  *
- * @category initialize
+ * @category `initialize`
  */
-export interface InitializeRequest extends Request {
+export interface InitializeRequest extends JSONRPCRequest {
   method: 'initialize';
-  params: {
-    /**
-     * The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.
-     */
-    protocolVersion: string;
-    capabilities: ClientCapabilities;
-    clientInfo: Implementation;
-  };
+  params: InitializeRequestParams;
 }
 
 /**
  * After receiving an initialize request from the client, the server sends this response.
  *
- * @category initialize
+ * @category `initialize`
  */
 export interface InitializeResult extends Result {
   /**
@@ -227,14 +349,17 @@ export interface InitializeResult extends Result {
 /**
  * This notification is sent from the client to the server after initialization has finished.
  *
- * @category notifications/initialized
+ * @category `notifications/initialized`
  */
-export interface InitializedNotification extends Notification {
+export interface InitializedNotification extends JSONRPCNotification {
   method: 'notifications/initialized';
+  params?: NotificationParams;
 }
 
 /**
  * Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.
+ *
+ * @category `initialize`
  */
 export interface ClientCapabilities {
   /**
@@ -253,15 +378,64 @@ export interface ClientCapabilities {
   /**
    * Present if the client supports sampling from an LLM.
    */
-  sampling?: object;
+  sampling?: {
+    /**
+     * Whether the client supports context inclusion via includeContext parameter.
+     * If not declared, servers SHOULD only use `includeContext: "none"` (or omit it).
+     */
+    context?: object;
+    /**
+     * Whether the client supports tool use via tools and toolChoice parameters.
+     */
+    tools?: object;
+  };
   /**
    * Present if the client supports elicitation from the server.
    */
-  elicitation?: object;
+  elicitation?: { form?: object; url?: object };
+
+  /**
+   * Present if the client supports task-augmented requests.
+   */
+  tasks?: {
+    /**
+     * Whether this client supports tasks/list.
+     */
+    list?: object;
+    /**
+     * Whether this client supports tasks/cancel.
+     */
+    cancel?: object;
+    /**
+     * Specifies which request types can be augmented with tasks.
+     */
+    requests?: {
+      /**
+       * Task support for sampling-related requests.
+       */
+      sampling?: {
+        /**
+         * Whether the client supports task-augmented sampling/createMessage requests.
+         */
+        createMessage?: object;
+      };
+      /**
+       * Task support for elicitation-related requests.
+       */
+      elicitation?: {
+        /**
+         * Whether the client supports task-augmented elicitation/create requests.
+         */
+        create?: object;
+      };
+    };
+  };
 }
 
 /**
  * Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.
+ *
+ * @category `initialize`
  */
 export interface ServerCapabilities {
   /**
@@ -307,6 +481,97 @@ export interface ServerCapabilities {
      */
     listChanged?: boolean;
   };
+  /**
+   * Present if the server supports task-augmented requests.
+   */
+  tasks?: {
+    /**
+     * Whether this server supports tasks/list.
+     */
+    list?: object;
+    /**
+     * Whether this server supports tasks/cancel.
+     */
+    cancel?: object;
+    /**
+     * Specifies which request types can be augmented with tasks.
+     */
+    requests?: {
+      /**
+       * Task support for tool-related requests.
+       */
+      tools?: {
+        /**
+         * Whether the server supports task-augmented tools/call requests.
+         */
+        call?: object;
+      };
+    };
+  };
+}
+
+/**
+ * An optionally-sized icon that can be displayed in a user interface.
+ *
+ * @category Common Types
+ */
+export interface Icon {
+  /**
+   * A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a
+   * `data:` URI with Base64-encoded image data.
+   *
+   * Consumers SHOULD takes steps to ensure URLs serving icons are from the
+   * same domain as the client/server or a trusted domain.
+   *
+   * Consumers SHOULD take appropriate precautions when consuming SVGs as they can contain
+   * executable JavaScript.
+   *
+   * @format uri
+   */
+  src: string;
+
+  /**
+   * Optional MIME type override if the source MIME type is missing or generic.
+   * For example: `"image/png"`, `"image/jpeg"`, or `"image/svg+xml"`.
+   */
+  mimeType?: string;
+
+  /**
+   * Optional array of strings that specify sizes at which the icon can be used.
+   * Each string should be in WxH format (e.g., `"48x48"`, `"96x96"`) or `"any"` for scalable formats like SVG.
+   *
+   * If not provided, the client should assume that the icon can be used at any size.
+   */
+  sizes?: string[];
+
+  /**
+   * Optional specifier for the theme this icon is designed for. `light` indicates
+   * the icon is designed to be used with a light background, and `dark` indicates
+   * the icon is designed to be used with a dark background.
+   *
+   * If not provided, the client should assume the icon can be used with any theme.
+   */
+  theme?: 'light' | 'dark';
+}
+
+/**
+ * Base interface to add `icons` property.
+ *
+ * @internal
+ */
+export interface Icons {
+  /**
+   * Optional set of sized icons that the client can display in a user interface.
+   *
+   * Clients that support rendering icons MUST support at least the following MIME types:
+   * - `image/png` - PNG images (safe, universal compatibility)
+   * - `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)
+   *
+   * Clients that support rendering icons SHOULD also support:
+   * - `image/svg+xml` - SVG images (scalable but requires security precautions)
+   * - `image/webp` - WebP images (modern, efficient format)
+   */
+  icons?: Icon[];
 }
 
 /**
@@ -332,64 +597,98 @@ export interface BaseMetadata {
 }
 
 /**
- * Describes the name and version of an MCP implementation, with an optional title for UI representation.
+ * Describes the MCP implementation.
+ *
+ * @category `initialize`
  */
-export interface Implementation extends BaseMetadata {
+export interface Implementation extends BaseMetadata, Icons {
   version: string;
+
+  /**
+   * An optional human-readable description of what this implementation does.
+   *
+   * This can be used by clients or servers to provide context about their purpose
+   * and capabilities. For example, a server might describe the types of resources
+   * or tools it provides, while a client might describe its intended use case.
+   */
+  description?: string;
+
+  /**
+   * An optional URL of the website for this implementation.
+   *
+   * @format uri
+   */
+  websiteUrl?: string;
 }
 
 /* Ping */
 /**
  * A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.
  *
- * @category ping
+ * @category `ping`
  */
-export interface PingRequest extends Request {
+export interface PingRequest extends JSONRPCRequest {
   method: 'ping';
+  params?: RequestParams;
 }
 
 /* Progress notifications */
+
+/**
+ * Parameters for a `notifications/progress` notification.
+ *
+ * @category `notifications/progress`
+ */
+export interface ProgressNotificationParams extends NotificationParams {
+  /**
+   * The progress token which was given in the initial request, used to associate this notification with the request that is proceeding.
+   */
+  progressToken: ProgressToken;
+  /**
+   * The progress thus far. This should increase every time progress is made, even if the total is unknown.
+   *
+   * @TJS-type number
+   */
+  progress: number;
+  /**
+   * Total number of items to process (or total progress required), if known.
+   *
+   * @TJS-type number
+   */
+  total?: number;
+  /**
+   * An optional message describing the current progress.
+   */
+  message?: string;
+}
+
 /**
  * An out-of-band notification used to inform the receiver of a progress update for a long-running request.
  *
- * @category notifications/progress
+ * @category `notifications/progress`
  */
-export interface ProgressNotification extends Notification {
+export interface ProgressNotification extends JSONRPCNotification {
   method: 'notifications/progress';
-  params: {
-    /**
-     * The progress token which was given in the initial request, used to associate this notification with the request that is proceeding.
-     */
-    progressToken: ProgressToken;
-    /**
-     * The progress thus far. This should increase every time progress is made, even if the total is unknown.
-     *
-     * @TJS-type number
-     */
-    progress: number;
-    /**
-     * Total number of items to process (or total progress required), if known.
-     *
-     * @TJS-type number
-     */
-    total?: number;
-    /**
-     * An optional message describing the current progress.
-     */
-    message?: string;
-  };
+  params: ProgressNotificationParams;
 }
 
 /* Pagination */
+/**
+ * Common parameters for paginated requests.
+ *
+ * @internal
+ */
+export interface PaginatedRequestParams extends RequestParams {
+  /**
+   * An opaque token representing the current pagination position.
+   * If provided, the server should return results starting after this cursor.
+   */
+  cursor?: Cursor;
+}
+
 /** @internal */
-export interface PaginatedRequest extends Request {
-  params?: {
-    /**
-     * An opaque token representing the current pagination position.
-     * If provided, the server should return results starting after this cursor.
-     */
-    cursor?: Cursor;
-  };
+export interface PaginatedRequest extends JSONRPCRequest {
+  params?: PaginatedRequestParams;
 }
 
 /** @internal */
@@ -405,7 +704,7 @@ export interface PaginatedResult extends Result {
 /**
  * Sent from the client to request a list of resources the server has.
  *
- * @category resources/list
+ * @category `resources/list`
  */
 export interface ListResourcesRequest extends PaginatedRequest {
   method: 'resources/list';
@@ -414,7 +713,7 @@ export interface ListResourcesRequest extends PaginatedRequest {
 /**
  * The server's response to a resources/list request from the client.
  *
- * @category resources/list
+ * @category `resources/list`
  */
 export interface ListResourcesResult extends PaginatedResult {
   resources: Resource[];
@@ -423,7 +722,7 @@ export interface ListResourcesResult extends PaginatedResult {
 /**
  * Sent from the client to request a list of resource templates the server has.
  *
- * @category resources/templates/list
+ * @category `resources/templates/list`
  */
 export interface ListResourceTemplatesRequest extends PaginatedRequest {
   method: 'resources/templates/list';
@@ -432,33 +731,48 @@ export interface ListResourceTemplatesRequest extends PaginatedRequest {
 /**
  * The server's response to a resources/templates/list request from the client.
  *
- * @category resources/templates/list
+ * @category `resources/templates/list`
  */
 export interface ListResourceTemplatesResult extends PaginatedResult {
   resourceTemplates: ResourceTemplate[];
 }
 
 /**
+ * Common parameters when working with resources.
+ *
+ * @internal
+ */
+export interface ResourceRequestParams extends RequestParams {
+  /**
+   * The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.
+   *
+   * @format uri
+   */
+  uri: string;
+}
+
+/**
+ * Parameters for a `resources/read` request.
+ *
+ * @category `resources/read`
+ */
+
+export interface ReadResourceRequestParams extends ResourceRequestParams {}
+
+/**
  * Sent from the client to the server, to read a specific resource URI.
  *
- * @category resources/read
+ * @category `resources/read`
  */
-export interface ReadResourceRequest extends Request {
+export interface ReadResourceRequest extends JSONRPCRequest {
   method: 'resources/read';
-  params: {
-    /**
-     * The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.
-     *
-     * @format uri
-     */
-    uri: string;
-  };
+  params: ReadResourceRequestParams;
 }
 
 /**
  * The server's response to a resources/read request from the client.
  *
- * @category resources/read
+ * @category `resources/read`
  */
 export interface ReadResourceResult extends Result {
   contents: (TextResourceContents | BlobResourceContents)[];
@@ -467,67 +781,79 @@ export interface ReadResourceResult extends Result {
 /**
  * An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.
  *
- * @category notifications/resources/list_changed
+ * @category `notifications/resources/list_changed`
  */
-export interface ResourceListChangedNotification extends Notification {
+export interface ResourceListChangedNotification extends JSONRPCNotification {
   method: 'notifications/resources/list_changed';
+  params?: NotificationParams;
 }
+
+/**
+ * Parameters for a `resources/subscribe` request.
+ *
+ * @category `resources/subscribe`
+ */
+
+export interface SubscribeRequestParams extends ResourceRequestParams {}
 
 /**
  * Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.
  *
- * @category resources/subscribe
+ * @category `resources/subscribe`
  */
-export interface SubscribeRequest extends Request {
+export interface SubscribeRequest extends JSONRPCRequest {
   method: 'resources/subscribe';
-  params: {
-    /**
-     * The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.
-     *
-     * @format uri
-     */
-    uri: string;
-  };
+  params: SubscribeRequestParams;
 }
+
+/**
+ * Parameters for a `resources/unsubscribe` request.
+ *
+ * @category `resources/unsubscribe`
+ */
+
+export interface UnsubscribeRequestParams extends ResourceRequestParams {}
 
 /**
  * Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.
  *
- * @category resources/unsubscribe
+ * @category `resources/unsubscribe`
  */
-export interface UnsubscribeRequest extends Request {
+export interface UnsubscribeRequest extends JSONRPCRequest {
   method: 'resources/unsubscribe';
-  params: {
-    /**
-     * The URI of the resource to unsubscribe from.
-     *
-     * @format uri
-     */
-    uri: string;
-  };
+  params: UnsubscribeRequestParams;
+}
+
+/**
+ * Parameters for a `notifications/resources/updated` notification.
+ *
+ * @category `notifications/resources/updated`
+ */
+export interface ResourceUpdatedNotificationParams extends NotificationParams {
+  /**
+   * The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.
+   *
+   * @format uri
+   */
+  uri: string;
 }
 
 /**
  * A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.
  *
- * @category notifications/resources/updated
+ * @category `notifications/resources/updated`
  */
-export interface ResourceUpdatedNotification extends Notification {
+export interface ResourceUpdatedNotification extends JSONRPCNotification {
   method: 'notifications/resources/updated';
-  params: {
-    /**
-     * The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.
-     *
-     * @format uri
-     */
-    uri: string;
-  };
+  params: ResourceUpdatedNotificationParams;
 }
 
 /**
  * A known resource that the server is capable of reading.
+ *
+ * @category `resources/list`
  */
-export interface Resource extends BaseMetadata {
+export interface Resource extends BaseMetadata, Icons {
   /**
    * The URI of this resource.
    *
@@ -560,15 +886,17 @@ export interface Resource extends BaseMetadata {
   size?: number;
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
 
 /**
  * A template description for resources available on the server.
+ *
+ * @category `resources/templates/list`
  */
-export interface ResourceTemplate extends BaseMetadata {
+export interface ResourceTemplate extends BaseMetadata, Icons {
   /**
    * A URI template (according to RFC 6570) that can be used to construct resource URIs.
    *
@@ -594,13 +922,15 @@ export interface ResourceTemplate extends BaseMetadata {
   annotations?: Annotations;
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
 
 /**
  * The contents of a specific resource or sub-resource.
+ *
+ * @internal
  */
 export interface ResourceContents {
   /**
@@ -615,11 +945,14 @@ export interface ResourceContents {
   mimeType?: string;
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
 
+/**
+ * @category Content
+ */
 export interface TextResourceContents extends ResourceContents {
   /**
    * The text of the item. This must only be set if the item can actually be represented as text (not binary data).
@@ -627,6 +960,9 @@ export interface TextResourceContents extends ResourceContents {
   text: string;
 }
 
+/**
+ * @category Content
+ */
 export interface BlobResourceContents extends ResourceContents {
   /**
    * A base64-encoded string representing the binary data of the item.
@@ -640,7 +976,7 @@ export interface BlobResourceContents extends ResourceContents {
 /**
  * Sent from the client to request a list of prompts and prompt templates the server has.
  *
- * @category prompts/list
+ * @category `prompts/list`
  */
 export interface ListPromptsRequest extends PaginatedRequest {
   method: 'prompts/list';
@@ -649,35 +985,42 @@ export interface ListPromptsRequest extends PaginatedRequest {
 /**
  * The server's response to a prompts/list request from the client.
  *
- * @category prompts/list
+ * @category `prompts/list`
  */
 export interface ListPromptsResult extends PaginatedResult {
   prompts: Prompt[];
 }
 
 /**
+ * Parameters for a `prompts/get` request.
+ *
+ * @category `prompts/get`
+ */
+export interface GetPromptRequestParams extends RequestParams {
+  /**
+   * The name of the prompt or prompt template.
+   */
+  name: string;
+  /**
+   * Arguments to use for templating the prompt.
+   */
+  arguments?: { [key: string]: string };
+}
+
+/**
  * Used by the client to get a prompt provided by the server.
  *
- * @category prompts/get
+ * @category `prompts/get`
  */
-export interface GetPromptRequest extends Request {
+export interface GetPromptRequest extends JSONRPCRequest {
   method: 'prompts/get';
-  params: {
-    /**
-     * The name of the prompt or prompt template.
-     */
-    name: string;
-    /**
-     * Arguments to use for templating the prompt.
-     */
-    arguments?: { [key: string]: string };
-  };
+  params: GetPromptRequestParams;
 }
 
 /**
  * The server's response to a prompts/get request from the client.
  *
- * @category prompts/get
+ * @category `prompts/get`
  */
 export interface GetPromptResult extends Result {
   /**
@@ -689,25 +1032,30 @@ export interface GetPromptResult extends Result {
 
 /**
  * A prompt or prompt template that the server offers.
+ *
+ * @category `prompts/list`
  */
-export interface Prompt extends BaseMetadata {
+export interface Prompt extends BaseMetadata, Icons {
   /**
    * An optional description of what this prompt provides
    */
   description?: string;
+
   /**
    * A list of arguments to use for templating the prompt.
    */
   arguments?: PromptArgument[];
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
 
 /**
  * Describes an argument that a prompt can accept.
+ *
+ * @category `prompts/list`
  */
 export interface PromptArgument extends BaseMetadata {
   /**
@@ -722,6 +1070,8 @@ export interface PromptArgument extends BaseMetadata {
 
 /**
  * The sender or recipient of messages and data in a conversation.
+ *
+ * @category Common Types
  */
 export type Role = 'user' | 'assistant'
 
@@ -730,6 +1080,8 @@ export type Role = 'user' | 'assistant'
  *
  * This is similar to `SamplingMessage`, but also supports the embedding of
  * resources from the MCP server.
+ *
+ * @category `prompts/get`
  */
 export interface PromptMessage {
   role: Role;
@@ -740,6 +1092,8 @@ export interface PromptMessage {
  * A resource that the server is capable of reading, included in a prompt or tool call result.
  *
  * Note: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.
+ *
+ * @category Content
  */
 export interface ResourceLink extends Resource {
   type: 'resource_link';
@@ -750,6 +1104,8 @@ export interface ResourceLink extends Resource {
  *
  * It is up to the client how best to render embedded resources for the benefit
  * of the LLM and/or the user.
+ *
+ * @category Content
  */
 export interface EmbeddedResource {
   type: 'resource';
@@ -761,24 +1117,25 @@ export interface EmbeddedResource {
   annotations?: Annotations;
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
 /**
  * An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.
  *
- * @category notifications/prompts/list_changed
+ * @category `notifications/prompts/list_changed`
  */
-export interface PromptListChangedNotification extends Notification {
+export interface PromptListChangedNotification extends JSONRPCNotification {
   method: 'notifications/prompts/list_changed';
+  params?: NotificationParams;
 }
 
 /* Tools */
 /**
  * Sent from the client to request a list of tools the server has.
  *
- * @category tools/list
+ * @category `tools/list`
  */
 export interface ListToolsRequest extends PaginatedRequest {
   method: 'tools/list';
@@ -787,7 +1144,7 @@ export interface ListToolsRequest extends PaginatedRequest {
 /**
  * The server's response to a tools/list request from the client.
  *
- * @category tools/list
+ * @category `tools/list`
  */
 export interface ListToolsResult extends PaginatedResult {
   tools: Tool[];
@@ -796,7 +1153,7 @@ export interface ListToolsResult extends PaginatedResult {
 /**
  * The server's response to a tool call.
  *
- * @category tools/call
+ * @category `tools/call`
  */
 export interface CallToolResult extends Result {
   /**
@@ -827,25 +1184,39 @@ export interface CallToolResult extends Result {
 }
 
 /**
+ * Parameters for a `tools/call` request.
+ *
+ * @category `tools/call`
+ */
+export interface CallToolRequestParams extends TaskAugmentedRequestParams {
+  /**
+   * The name of the tool.
+   */
+  name: string;
+  /**
+   * Arguments to use for the tool call.
+   */
+  arguments?: { [key: string]: unknown };
+}
+
+/**
  * Used by the client to invoke a tool provided by the server.
  *
- * @category tools/call
+ * @category `tools/call`
  */
-export interface CallToolRequest extends Request {
+export interface CallToolRequest extends JSONRPCRequest {
   method: 'tools/call';
-  params: {
-    name: string;
-    arguments?: { [key: string]: unknown };
-  };
+  params: CallToolRequestParams;
 }
 
 /**
  * An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.
  *
- * @category notifications/tools/list_changed
+ * @category `notifications/tools/list_changed`
  */
-export interface ToolListChangedNotification extends Notification {
+export interface ToolListChangedNotification extends JSONRPCNotification {
   method: 'notifications/tools/list_changed';
+  params?: NotificationParams;
 }
 
 /**
@@ -857,6 +1228,8 @@ export interface ToolListChangedNotification extends Notification {
  *
  * Clients should never make tool use decisions based on ToolAnnotations
  * received from untrusted servers.
+ *
+ * @category `tools/list`
  */
 export interface ToolAnnotations {
   /**
@@ -883,7 +1256,7 @@ export interface ToolAnnotations {
 
   /**
    * If true, calling the tool repeatedly with the same arguments
-   * will have no additional effect on the its environment.
+   * will have no additional effect on its environment.
    *
    * (This property is meaningful only when `readOnlyHint == false`)
    *
@@ -903,9 +1276,31 @@ export interface ToolAnnotations {
 }
 
 /**
- * Definition for a tool the client can call.
+ * Execution-related properties for a tool.
+ *
+ * @category `tools/list`
  */
-export interface Tool extends BaseMetadata {
+export interface ToolExecution {
+  /**
+   * Indicates whether this tool supports task-augmented execution.
+   * This allows clients to handle long-running operations through polling
+   * the task system.
+   *
+   * - "forbidden": Tool does not support task-augmented execution (default when absent)
+   * - "optional": Tool may support task-augmented execution
+   * - "required": Tool requires task-augmented execution
+   *
+   * Default: "forbidden"
+   */
+  taskSupport?: 'forbidden' | 'optional' | 'required';
+}
+
+/**
+ * Definition for a tool the client can call.
+ *
+ * @category `tools/list`
+ */
+export interface Tool extends BaseMetadata, Icons {
   /**
    * A human-readable description of the tool.
    *
@@ -917,16 +1312,26 @@ export interface Tool extends BaseMetadata {
    * A JSON Schema object defining the expected parameters for the tool.
    */
   inputSchema: {
+    $schema?: string;
     type: 'object';
     properties?: { [key: string]: object };
     required?: string[];
   };
 
   /**
+   * Execution-related properties for this tool.
+   */
+  execution?: ToolExecution;
+
+  /**
    * An optional JSON Schema object defining the structure of the tool's output returned in
    * the structuredContent field of a CallToolResult.
+   *
+   * Defaults to JSON Schema 2020-12 when no explicit $schema is provided.
+   * Currently restricted to type: "object" at the root level.
    */
   outputSchema?: {
+    $schema?: string;
     type: 'object';
     properties?: { [key: string]: object };
     required?: string[];
@@ -940,48 +1345,264 @@ export interface Tool extends BaseMetadata {
   annotations?: ToolAnnotations;
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
 
-/* Logging */
+/* Tasks */
+
 /**
- * A request from the client to the server, to enable or adjust logging.
+ * The status of a task.
  *
- * @category logging/setLevel
+ * @category `tasks`
  */
-export interface SetLevelRequest extends Request {
-  method: 'logging/setLevel';
+export type TaskStatus =
+  | 'working' // The request is currently being processed
+  | 'input_required' // The task is waiting for input (e.g., elicitation or sampling)
+  | 'completed' // The request completed successfully and results are available
+  | 'failed' // The associated request did not complete successfully. For tool calls specifically, this includes cases where the tool call result has `isError` set to true.
+  | 'cancelled' // The request was cancelled before completion
+
+/**
+ * Metadata for augmenting a request with task execution.
+ * Include this in the `task` field of the request parameters.
+ *
+ * @category `tasks`
+ */
+export interface TaskMetadata {
+  /**
+   * Requested duration in milliseconds to retain task from creation.
+   */
+  ttl?: number;
+}
+
+/**
+ * Metadata for associating messages with a task.
+ * Include this in the `_meta` field under the key `io.modelcontextprotocol/related-task`.
+ *
+ * @category `tasks`
+ */
+export interface RelatedTaskMetadata {
+  /**
+   * The task identifier this message is associated with.
+   */
+  taskId: string;
+}
+
+/**
+ * Data associated with a task.
+ *
+ * @category `tasks`
+ */
+export interface Task {
+  /**
+   * The task identifier.
+   */
+  taskId: string;
+
+  /**
+   * Current task state.
+   */
+  status: TaskStatus;
+
+  /**
+   * Optional human-readable message describing the current task state.
+   * This can provide context for any status, including:
+   * - Reasons for "cancelled" status
+   * - Summaries for "completed" status
+   * - Diagnostic information for "failed" status (e.g., error details, what went wrong)
+   */
+  statusMessage?: string;
+
+  /**
+   * ISO 8601 timestamp when the task was created.
+   */
+  createdAt: string;
+
+  /**
+   * ISO 8601 timestamp when the task was last updated.
+   */
+  lastUpdatedAt: string;
+
+  /**
+   * Actual retention duration from creation in milliseconds, null for unlimited.
+   * @nullable
+   */
+  ttl: number | null;
+
+  /**
+   * Suggested polling interval in milliseconds.
+   */
+  pollInterval?: number;
+}
+
+/**
+ * A response to a task-augmented request.
+ *
+ * @category `tasks`
+ */
+export interface CreateTaskResult extends Result {
+  task: Task;
+}
+
+/**
+ * A request to retrieve the state of a task.
+ *
+ * @category `tasks/get`
+ */
+export interface GetTaskRequest extends JSONRPCRequest {
+  method: 'tasks/get';
   params: {
     /**
-     * The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.
+     * The task identifier to query.
      */
-    level: LoggingLevel;
+    taskId: string;
   };
 }
 
 /**
- * Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.
+ * The response to a tasks/get request.
  *
- * @category notifications/message
+ * @category `tasks/get`
  */
-export interface LoggingMessageNotification extends Notification {
-  method: 'notifications/message';
+export type GetTaskResult = Result & Task
+
+/**
+ * A request to retrieve the result of a completed task.
+ *
+ * @category `tasks/result`
+ */
+export interface GetTaskPayloadRequest extends JSONRPCRequest {
+  method: 'tasks/result';
   params: {
     /**
-     * The severity of this log message.
+     * The task identifier to retrieve results for.
      */
-    level: LoggingLevel;
-    /**
-     * An optional name of the logger issuing this message.
-     */
-    logger?: string;
-    /**
-     * The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here.
-     */
-    data: unknown;
+    taskId: string;
   };
+}
+
+/**
+ * The response to a tasks/result request.
+ * The structure matches the result type of the original request.
+ * For example, a tools/call task would return the CallToolResult structure.
+ *
+ * @category `tasks/result`
+ */
+export interface GetTaskPayloadResult extends Result {
+  [key: string]: unknown;
+}
+
+/**
+ * A request to cancel a task.
+ *
+ * @category `tasks/cancel`
+ */
+export interface CancelTaskRequest extends JSONRPCRequest {
+  method: 'tasks/cancel';
+  params: {
+    /**
+     * The task identifier to cancel.
+     */
+    taskId: string;
+  };
+}
+
+/**
+ * The response to a tasks/cancel request.
+ *
+ * @category `tasks/cancel`
+ */
+export type CancelTaskResult = Result & Task
+
+/**
+ * A request to retrieve a list of tasks.
+ *
+ * @category `tasks/list`
+ */
+export interface ListTasksRequest extends PaginatedRequest {
+  method: 'tasks/list';
+}
+
+/**
+ * The response to a tasks/list request.
+ *
+ * @category `tasks/list`
+ */
+export interface ListTasksResult extends PaginatedResult {
+  tasks: Task[];
+}
+
+/**
+ * Parameters for a `notifications/tasks/status` notification.
+ *
+ * @category `notifications/tasks/status`
+ */
+export type TaskStatusNotificationParams = NotificationParams & Task
+
+/**
+ * An optional notification from the receiver to the requestor, informing them that a task's status has changed. Receivers are not required to send these notifications.
+ *
+ * @category `notifications/tasks/status`
+ */
+export interface TaskStatusNotification extends JSONRPCNotification {
+  method: 'notifications/tasks/status';
+  params: TaskStatusNotificationParams;
+}
+
+/* Logging */
+
+/**
+ * Parameters for a `logging/setLevel` request.
+ *
+ * @category `logging/setLevel`
+ */
+export interface SetLevelRequestParams extends RequestParams {
+  /**
+   * The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.
+   */
+  level: LoggingLevel;
+}
+
+/**
+ * A request from the client to the server, to enable or adjust logging.
+ *
+ * @category `logging/setLevel`
+ */
+export interface SetLevelRequest extends JSONRPCRequest {
+  method: 'logging/setLevel';
+  params: SetLevelRequestParams;
+}
+
+/**
+ * Parameters for a `notifications/message` notification.
+ *
+ * @category `notifications/message`
+ */
+export interface LoggingMessageNotificationParams extends NotificationParams {
+  /**
+   * The severity of this log message.
+   */
+  level: LoggingLevel;
+  /**
+   * An optional name of the logger issuing this message.
+   */
+  logger?: string;
+  /**
+   * The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here.
+   */
+  data: unknown;
+}
+
+/**
+ * JSONRPCNotification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.
+ *
+ * @category `notifications/message`
+ */
+export interface LoggingMessageNotification extends JSONRPCNotification {
+  method: 'notifications/message';
+  params: LoggingMessageNotificationParams;
 }
 
 /**
@@ -989,6 +1610,8 @@ export interface LoggingMessageNotification extends Notification {
  *
  * These map to syslog message severities, as specified in RFC-5424:
  * https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
+ *
+ * @category Common Types
  */
 export type LoggingLevel =
   | 'debug'
@@ -1002,72 +1625,140 @@ export type LoggingLevel =
 
 /* Sampling */
 /**
- * A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.
+ * Parameters for a `sampling/createMessage` request.
  *
- * @category sampling/createMessage
+ * @category `sampling/createMessage`
  */
-export interface CreateMessageRequest extends Request {
-  method: 'sampling/createMessage';
-  params: {
-    messages: SamplingMessage[];
-    /**
-     * The server's preferences for which model to select. The client MAY ignore these preferences.
-     */
-    modelPreferences?: ModelPreferences;
-    /**
-     * An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.
-     */
-    systemPrompt?: string;
-    /**
-     * A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.
-     */
-    includeContext?: 'none' | 'thisServer' | 'allServers';
-    /**
-     * @TJS-type number
-     */
-    temperature?: number;
-    /**
-     * The maximum number of tokens to sample, as requested by the server. The client MAY choose to sample fewer tokens than requested.
-     */
-    maxTokens: number;
-    stopSequences?: string[];
-    /**
-     * Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.
-     */
-    metadata?: object;
-  };
+export interface CreateMessageRequestParams extends TaskAugmentedRequestParams {
+  messages: SamplingMessage[];
+  /**
+   * The server's preferences for which model to select. The client MAY ignore these preferences.
+   */
+  modelPreferences?: ModelPreferences;
+  /**
+   * An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.
+   */
+  systemPrompt?: string;
+  /**
+   * A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.
+   * The client MAY ignore this request.
+   *
+   * Default is "none". Values "thisServer" and "allServers" are soft-deprecated. Servers SHOULD only use these values if the client
+   * declares ClientCapabilities.sampling.context. These values may be removed in future spec releases.
+   */
+  includeContext?: 'none' | 'thisServer' | 'allServers';
+  /**
+   * @TJS-type number
+   */
+  temperature?: number;
+  /**
+   * The requested maximum number of tokens to sample (to prevent runaway completions).
+   *
+   * The client MAY choose to sample fewer tokens than the requested maximum.
+   */
+  maxTokens: number;
+  stopSequences?: string[];
+  /**
+   * Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.
+   */
+  metadata?: object;
+  /**
+   * Tools that the model may use during generation.
+   * The client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.
+   */
+  tools?: Tool[];
+  /**
+   * Controls how the model uses tools.
+   * The client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.
+   * Default is `{ mode: "auto" }`.
+   */
+  toolChoice?: ToolChoice;
 }
 
 /**
- * The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.
+ * Controls tool selection behavior for sampling requests.
  *
- * @category sampling/createMessage
+ * @category `sampling/createMessage`
+ */
+export interface ToolChoice {
+  /**
+   * Controls the tool use ability of the model:
+   * - "auto": Model decides whether to use tools (default)
+   * - "required": Model MUST use at least one tool before completing
+   * - "none": Model MUST NOT use any tools
+   */
+  mode?: 'auto' | 'required' | 'none';
+}
+
+/**
+ * A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.
+ *
+ * @category `sampling/createMessage`
+ */
+export interface CreateMessageRequest extends JSONRPCRequest {
+  method: 'sampling/createMessage';
+  params: CreateMessageRequestParams;
+}
+
+/**
+ * The client's response to a sampling/createMessage request from the server.
+ * The client should inform the user before returning the sampled message, to allow them
+ * to inspect the response (human in the loop) and decide whether to allow the server to see it.
+ *
+ * @category `sampling/createMessage`
  */
 export interface CreateMessageResult extends Result, SamplingMessage {
   /**
    * The name of the model that generated the message.
    */
   model: string;
+
   /**
    * The reason why sampling stopped, if known.
+   *
+   * Standard values:
+   * - "endTurn": Natural end of the assistant's turn
+   * - "stopSequence": A stop sequence was encountered
+   * - "maxTokens": Maximum token limit was reached
+   * - "toolUse": The model wants to use one or more tools
+   *
+   * This field is an open string to allow for provider-specific stop reasons.
    */
-  stopReason?: 'endTurn' | 'stopSequence' | 'maxTokens' | string;
+  stopReason?: 'endTurn' | 'stopSequence' | 'maxTokens' | 'toolUse' | string;
 }
 
 /**
  * Describes a message issued to or received from an LLM API.
+ *
+ * @category `sampling/createMessage`
  */
 export interface SamplingMessage {
   role: Role;
-  content: TextContent | ImageContent | AudioContent;
+  content: SamplingMessageContentBlock | SamplingMessageContentBlock[];
+  /**
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /**
+ * @category `sampling/createMessage`
+ */
+export type SamplingMessageContentBlock =
+  | TextContent
+  | ImageContent
+  | AudioContent
+  | ToolUseContent
+  | ToolResultContent
+
+/**
  * Optional annotations for the client. The client can use annotations to inform how objects are used or displayed
+ *
+ * @category Common Types
  */
 export interface Annotations {
   /**
-   * Describes who the intended customer of this object or data is.
+   * Describes who the intended audience of this object or data is.
    *
    * It can include multiple entries to indicate content useful for multiple audiences (e.g., `["user", "assistant"]`).
    */
@@ -1097,15 +1788,16 @@ export interface Annotations {
   lastModified?: string;
 }
 
+/**
+ * @category Content
+ */
 export type ContentBlock =
-  | TextContent
-  | ImageContent
-  | AudioContent
-  | ResourceLink
-  | EmbeddedResource
+  TextContent | ImageContent | AudioContent | ResourceLink | EmbeddedResource
 
 /**
  * Text provided to or from an LLM.
+ *
+ * @category Content
  */
 export interface TextContent {
   type: 'text';
@@ -1121,13 +1813,15 @@ export interface TextContent {
   annotations?: Annotations;
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
 
 /**
  * An image provided to or from an LLM.
+ *
+ * @category Content
  */
 export interface ImageContent {
   type: 'image';
@@ -1150,13 +1844,15 @@ export interface ImageContent {
   annotations?: Annotations;
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
 
 /**
  * Audio provided to or from an LLM.
+ *
+ * @category Content
  */
 export interface AudioContent {
   type: 'audio';
@@ -1179,7 +1875,88 @@ export interface AudioContent {
   annotations?: Annotations;
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+   */
+  _meta?: { [key: string]: unknown };
+}
+
+/**
+ * A request from the assistant to call a tool.
+ *
+ * @category `sampling/createMessage`
+ */
+export interface ToolUseContent {
+  type: 'tool_use';
+
+  /**
+   * A unique identifier for this tool use.
+   *
+   * This ID is used to match tool results to their corresponding tool uses.
+   */
+  id: string;
+
+  /**
+   * The name of the tool to call.
+   */
+  name: string;
+
+  /**
+   * The arguments to pass to the tool, conforming to the tool's input schema.
+   */
+  input: { [key: string]: unknown };
+
+  /**
+   * Optional metadata about the tool use. Clients SHOULD preserve this field when
+   * including tool uses in subsequent sampling requests to enable caching optimizations.
+   *
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+   */
+  _meta?: { [key: string]: unknown };
+}
+
+/**
+ * The result of a tool use, provided by the user back to the assistant.
+ *
+ * @category `sampling/createMessage`
+ */
+export interface ToolResultContent {
+  type: 'tool_result';
+
+  /**
+   * The ID of the tool use this result corresponds to.
+   *
+   * This MUST match the ID from a previous ToolUseContent.
+   */
+  toolUseId: string;
+
+  /**
+   * The unstructured result content of the tool use.
+   *
+   * This has the same format as CallToolResult.content and can include text, images,
+   * audio, resource links, and embedded resources.
+   */
+  content: ContentBlock[];
+
+  /**
+   * An optional structured result object.
+   *
+   * If the tool defined an outputSchema, this SHOULD conform to that schema.
+   */
+  structuredContent?: { [key: string]: unknown };
+
+  /**
+   * Whether the tool use resulted in an error.
+   *
+   * If true, the content typically describes the error that occurred.
+   * Default: false
+   */
+  isError?: boolean;
+
+  /**
+   * Optional metadata about the tool result. Clients SHOULD preserve this field when
+   * including tool results in subsequent sampling requests to enable caching optimizations.
+   *
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -1196,6 +1973,8 @@ export interface AudioContent {
  * These preferences are always advisory. The client MAY ignore them. It is also
  * up to the client to decide how to interpret these preferences and how to
  * balance them against other considerations.
+ *
+ * @category `sampling/createMessage`
  */
 export interface ModelPreferences {
   /**
@@ -1248,6 +2027,8 @@ export interface ModelPreferences {
  *
  * Keys not declared here are currently left unspecified by the spec and are up
  * to the client to interpret.
+ *
+ * @category `sampling/createMessage`
  */
 export interface ModelHint {
   /**
@@ -1266,44 +2047,51 @@ export interface ModelHint {
 
 /* Autocomplete */
 /**
+ * Parameters for a `completion/complete` request.
+ *
+ * @category `completion/complete`
+ */
+export interface CompleteRequestParams extends RequestParams {
+  ref: PromptReference | ResourceTemplateReference;
+  /**
+   * The argument's information
+   */
+  argument: {
+    /**
+     * The name of the argument
+     */
+    name: string;
+    /**
+     * The value of the argument to use for completion matching.
+     */
+    value: string;
+  };
+
+  /**
+   * Additional, optional context for completions
+   */
+  context?: {
+    /**
+     * Previously-resolved variables in a URI template or prompt.
+     */
+    arguments?: { [key: string]: string };
+  };
+}
+
+/**
  * A request from the client to the server, to ask for completion options.
  *
- * @category completion/complete
+ * @category `completion/complete`
  */
-export interface CompleteRequest extends Request {
+export interface CompleteRequest extends JSONRPCRequest {
   method: 'completion/complete';
-  params: {
-    ref: PromptReference | ResourceTemplateReference;
-    /**
-     * The argument's information
-     */
-    argument: {
-      /**
-       * The name of the argument
-       */
-      name: string;
-      /**
-       * The value of the argument to use for completion matching.
-       */
-      value: string;
-    };
-
-    /**
-     * Additional, optional context for completions
-     */
-    context?: {
-      /**
-       * Previously-resolved variables in a URI template or prompt.
-       */
-      arguments?: { [key: string]: string };
-    };
-  };
+  params: CompleteRequestParams;
 }
 
 /**
  * The server's response to a completion/complete request
  *
- * @category completion/complete
+ * @category `completion/complete`
  */
 export interface CompleteResult extends Result {
   completion: {
@@ -1324,6 +2112,8 @@ export interface CompleteResult extends Result {
 
 /**
  * A reference to a resource or resource template definition.
+ *
+ * @category `completion/complete`
  */
 export interface ResourceTemplateReference {
   type: 'ref/resource';
@@ -1337,6 +2127,8 @@ export interface ResourceTemplateReference {
 
 /**
  * Identifies a prompt.
+ *
+ * @category `completion/complete`
  */
 export interface PromptReference extends BaseMetadata {
   type: 'ref/prompt';
@@ -1352,10 +2144,11 @@ export interface PromptReference extends BaseMetadata {
  * This request is typically used when the server needs to understand the file system
  * structure or access specific locations that the client has permission to read from.
  *
- * @category roots/list
+ * @category `roots/list`
  */
-export interface ListRootsRequest extends Request {
+export interface ListRootsRequest extends JSONRPCRequest {
   method: 'roots/list';
+  params?: RequestParams;
 }
 
 /**
@@ -1363,7 +2156,7 @@ export interface ListRootsRequest extends Request {
  * This result contains an array of Root objects, each representing a root directory
  * or file that the server can operate on.
  *
- * @category roots/list
+ * @category `roots/list`
  */
 export interface ListRootsResult extends Result {
   roots: Root[];
@@ -1371,6 +2164,8 @@ export interface ListRootsResult extends Result {
 
 /**
  * Represents a root directory or file that the server can operate on.
+ *
+ * @category `roots/list`
  */
 export interface Root {
   /**
@@ -1389,7 +2184,7 @@ export interface Root {
   name?: string;
 
   /**
-   * See [specification/2025-06-18/basic/index#general-fields] for notes on _meta usage.
+   * See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -1399,48 +2194,103 @@ export interface Root {
  * This notification should be sent whenever the client adds, removes, or modifies any root.
  * The server should then request an updated list of roots using the ListRootsRequest.
  *
- * @category notifications/roots/list_changed
+ * @category `notifications/roots/list_changed`
  */
-export interface RootsListChangedNotification extends Notification {
+export interface RootsListChangedNotification extends JSONRPCNotification {
   method: 'notifications/roots/list_changed';
+  params?: NotificationParams;
 }
+
+/**
+ * The parameters for a request to elicit non-sensitive information from the user via a form in the client.
+ *
+ * @category `elicitation/create`
+ */
+export interface ElicitRequestFormParams extends TaskAugmentedRequestParams {
+  /**
+   * The elicitation mode.
+   */
+  mode?: 'form';
+
+  /**
+   * The message to present to the user describing what information is being requested.
+   */
+  message: string;
+
+  /**
+   * A restricted subset of JSON Schema.
+   * Only top-level properties are allowed, without nesting.
+   */
+  requestedSchema: {
+    $schema?: string;
+    type: 'object';
+    properties: {
+      [key: string]: PrimitiveSchemaDefinition;
+    };
+    required?: string[];
+  };
+}
+
+/**
+ * The parameters for a request to elicit information from the user via a URL in the client.
+ *
+ * @category `elicitation/create`
+ */
+export interface ElicitRequestURLParams extends TaskAugmentedRequestParams {
+  /**
+   * The elicitation mode.
+   */
+  mode: 'url';
+
+  /**
+   * The message to present to the user explaining why the interaction is needed.
+   */
+  message: string;
+
+  /**
+   * The ID of the elicitation, which must be unique within the context of the server.
+   * The client MUST treat this ID as an opaque value.
+   */
+  elicitationId: string;
+
+  /**
+   * The URL that the user should navigate to.
+   *
+   * @format uri
+   */
+  url: string;
+}
+
+/**
+ * The parameters for a request to elicit additional information from the user via the client.
+ *
+ * @category `elicitation/create`
+ */
+export type ElicitRequestParams =
+  ElicitRequestFormParams | ElicitRequestURLParams
 
 /**
  * A request from the server to elicit additional information from the user via the client.
  *
- * @category elicitation/create
+ * @category `elicitation/create`
  */
-export interface ElicitRequest extends Request {
+export interface ElicitRequest extends JSONRPCRequest {
   method: 'elicitation/create';
-  params: {
-    /**
-     * The message to present to the user.
-     */
-    message: string;
-    /**
-     * A restricted subset of JSON Schema.
-     * Only top-level properties are allowed, without nesting.
-     */
-    requestedSchema: {
-      type: 'object';
-      properties: {
-        [key: string]: PrimitiveSchemaDefinition;
-      };
-      required?: string[];
-    };
-  };
+  params: ElicitRequestParams;
 }
 
 /**
  * Restricted schema definitions that only allow primitive types
  * without nested objects or arrays.
+ *
+ * @category `elicitation/create`
  */
 export type PrimitiveSchemaDefinition =
-  | StringSchema
-  | NumberSchema
-  | BooleanSchema
-  | EnumSchema
+  StringSchema | NumberSchema | BooleanSchema | EnumSchema
 
+/**
+ * @category `elicitation/create`
+ */
 export interface StringSchema {
   type: 'string';
   title?: string;
@@ -1448,16 +2298,24 @@ export interface StringSchema {
   minLength?: number;
   maxLength?: number;
   format?: 'email' | 'uri' | 'date' | 'date-time';
+  default?: string;
 }
 
+/**
+ * @category `elicitation/create`
+ */
 export interface NumberSchema {
   type: 'number' | 'integer';
   title?: string;
   description?: string;
   minimum?: number;
   maximum?: number;
+  default?: number;
 }
 
+/**
+ * @category `elicitation/create`
+ */
 export interface BooleanSchema {
   type: 'boolean';
   title?: string;
@@ -1465,33 +2323,226 @@ export interface BooleanSchema {
   default?: boolean;
 }
 
-export interface EnumSchema {
+/**
+ * Schema for single-selection enumeration without display titles for options.
+ *
+ * @category `elicitation/create`
+ */
+export interface UntitledSingleSelectEnumSchema {
+  type: 'string';
+  /**
+   * Optional title for the enum field.
+   */
+  title?: string;
+  /**
+   * Optional description for the enum field.
+   */
+  description?: string;
+  /**
+   * Array of enum values to choose from.
+   */
+  enum: string[];
+  /**
+   * Optional default value.
+   */
+  default?: string;
+}
+
+/**
+ * Schema for single-selection enumeration with display titles for each option.
+ *
+ * @category `elicitation/create`
+ */
+export interface TitledSingleSelectEnumSchema {
+  type: 'string';
+  /**
+   * Optional title for the enum field.
+   */
+  title?: string;
+  /**
+   * Optional description for the enum field.
+   */
+  description?: string;
+  /**
+   * Array of enum options with values and display labels.
+   */
+  oneOf: Array<{
+    /**
+     * The enum value.
+     */
+    const: string;
+    /**
+     * Display label for this option.
+     */
+    title: string;
+  }>;
+  /**
+   * Optional default value.
+   */
+  default?: string;
+}
+
+/**
+ * @category `elicitation/create`
+ */
+// Combined single selection enumeration
+export type SingleSelectEnumSchema =
+  UntitledSingleSelectEnumSchema | TitledSingleSelectEnumSchema
+
+/**
+ * Schema for multiple-selection enumeration without display titles for options.
+ *
+ * @category `elicitation/create`
+ */
+export interface UntitledMultiSelectEnumSchema {
+  type: 'array';
+  /**
+   * Optional title for the enum field.
+   */
+  title?: string;
+  /**
+   * Optional description for the enum field.
+   */
+  description?: string;
+  /**
+   * Minimum number of items to select.
+   */
+  minItems?: number;
+  /**
+   * Maximum number of items to select.
+   */
+  maxItems?: number;
+  /**
+   * Schema for the array items.
+   */
+  items: {
+    type: 'string';
+    /**
+     * Array of enum values to choose from.
+     */
+    enum: string[];
+  };
+  /**
+   * Optional default value.
+   */
+  default?: string[];
+}
+
+/**
+ * Schema for multiple-selection enumeration with display titles for each option.
+ *
+ * @category `elicitation/create`
+ */
+export interface TitledMultiSelectEnumSchema {
+  type: 'array';
+  /**
+   * Optional title for the enum field.
+   */
+  title?: string;
+  /**
+   * Optional description for the enum field.
+   */
+  description?: string;
+  /**
+   * Minimum number of items to select.
+   */
+  minItems?: number;
+  /**
+   * Maximum number of items to select.
+   */
+  maxItems?: number;
+  /**
+   * Schema for array items with enum options and display labels.
+   */
+  items: {
+    /**
+     * Array of enum options with values and display labels.
+     */
+    anyOf: Array<{
+      /**
+       * The constant enum value.
+       */
+      const: string;
+      /**
+       * Display title for this option.
+       */
+      title: string;
+    }>;
+  };
+  /**
+   * Optional default value.
+   */
+  default?: string[];
+}
+
+/**
+ * @category `elicitation/create`
+ */
+// Combined multiple selection enumeration
+export type MultiSelectEnumSchema =
+  UntitledMultiSelectEnumSchema | TitledMultiSelectEnumSchema
+
+/**
+ * Use TitledSingleSelectEnumSchema instead.
+ * This interface will be removed in a future version.
+ *
+ * @category `elicitation/create`
+ */
+export interface LegacyTitledEnumSchema {
   type: 'string';
   title?: string;
   description?: string;
   enum: string[];
-  enumNames?: string[]; // Display names for enum values
+  /**
+   * (Legacy) Display names for enum values.
+   * Non-standard according to JSON schema 2020-12.
+   */
+  enumNames?: string[];
+  default?: string;
 }
+
+/**
+ * @category `elicitation/create`
+ */
+// Union type for all enum schemas
+export type EnumSchema =
+  SingleSelectEnumSchema | MultiSelectEnumSchema | LegacyTitledEnumSchema
 
 /**
  * The client's response to an elicitation request.
  *
- * @category elicitation/create
+ * @category `elicitation/create`
  */
 export interface ElicitResult extends Result {
   /**
    * The user action in response to the elicitation.
    * - "accept": User submitted the form/confirmed the action
-   * - "decline": User explicitly declined the action
+   * - "decline": User explicitly decline the action
    * - "cancel": User dismissed without making an explicit choice
    */
   action: 'accept' | 'decline' | 'cancel';
 
   /**
-   * The submitted form data, only present when action is "accept".
+   * The submitted form data, only present when action is "accept" and mode was "form".
    * Contains values matching the requested schema.
+   * Omitted for out-of-band mode responses.
    */
-  content?: { [key: string]: string | number | boolean };
+  content?: { [key: string]: string | number | boolean | string[] };
+}
+
+/**
+ * An optional notification from the server to the client, informing it of a completion of a out-of-band elicitation request.
+ *
+ * @category `notifications/elicitation/complete`
+ */
+export interface ElicitationCompleteNotification extends JSONRPCNotification {
+  method: 'notifications/elicitation/complete';
+  params: {
+    /**
+     * The ID of the elicitation that completed.
+     */
+    elicitationId: string;
+  };
 }
 
 /* Client messages */
@@ -1510,6 +2561,10 @@ export type ClientRequest =
   | UnsubscribeRequest
   | CallToolRequest
   | ListToolsRequest
+  | GetTaskRequest
+  | GetTaskPayloadRequest
+  | ListTasksRequest
+  | CancelTaskRequest
 
 /** @internal */
 export type ClientNotification =
@@ -1517,6 +2572,7 @@ export type ClientNotification =
   | ProgressNotification
   | InitializedNotification
   | RootsListChangedNotification
+  | TaskStatusNotification
 
 /** @internal */
 export type ClientResult =
@@ -1524,6 +2580,10 @@ export type ClientResult =
   | CreateMessageResult
   | ListRootsResult
   | ElicitResult
+  | GetTaskResult
+  | GetTaskPayloadResult
+  | ListTasksResult
+  | CancelTaskResult
 
 /* Server messages */
 /** @internal */
@@ -1532,6 +2592,10 @@ export type ServerRequest =
   | CreateMessageRequest
   | ListRootsRequest
   | ElicitRequest
+  | GetTaskRequest
+  | GetTaskPayloadRequest
+  | ListTasksRequest
+  | CancelTaskRequest
 
 /** @internal */
 export type ServerNotification =
@@ -1542,6 +2606,8 @@ export type ServerNotification =
   | ResourceListChangedNotification
   | ToolListChangedNotification
   | PromptListChangedNotification
+  | ElicitationCompleteNotification
+  | TaskStatusNotification
 
 /** @internal */
 export type ServerResult =
@@ -1555,3 +2621,7 @@ export type ServerResult =
   | ReadResourceResult
   | CallToolResult
   | ListToolsResult
+  | GetTaskResult
+  | GetTaskPayloadResult
+  | ListTasksResult
+  | CancelTaskResult

--- a/src/security.ts
+++ b/src/security.ts
@@ -168,6 +168,63 @@ export function validateElicitationRequest (message: string, schema: any): void 
 }
 
 /**
+ * Validate a URL mode elicitation request (2025-11-25).
+ *
+ * The spec forbids servers from putting anything sensitive in the URL, and
+ * forbids pre-authenticated URLs, because a malicious client could replay them
+ * to impersonate the user. We enforce what is mechanically checkable: a parseable
+ * http(s) URL carrying no embedded credentials.
+ */
+export function validateElicitationUrl (message: string, url: string): void {
+  if (message.length > MAX_STRING_LENGTH) {
+    throw new Error(`Elicitation message length exceeds maximum allowed length of ${MAX_STRING_LENGTH}`)
+  }
+
+  const sanitizedMessage = sanitizeString(message)
+  if (sanitizedMessage !== message) {
+    throw new Error('Elicitation message contains invalid characters')
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error('Elicitation URL is not a valid URL')
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`Elicitation URL must use http or https, got '${parsed.protocol}'`)
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new Error('Elicitation URL must not embed credentials')
+  }
+}
+
+/**
+ * Configured value for the allowed `Origin` headers.
+ *
+ * - `undefined` disables validation (non-browser deployments)
+ * - `'*'` or `true` accepts any origin
+ * - an array accepts exact origin matches only
+ */
+export type AllowedOrigins = string[] | '*' | true | undefined
+
+/**
+ * Check a request `Origin` against the configured allow-list.
+ *
+ * Requests without an `Origin` header are accepted: the header is set by browsers,
+ * and its absence means the request did not come from one. The 2025-11-25 revision
+ * clarified that a rejected origin must be answered with 403, not 400.
+ */
+export function isOriginAllowed (origin: string | undefined, allowed: AllowedOrigins): boolean {
+  if (allowed === undefined) return true
+  if (origin === undefined) return true
+  if (allowed === true || allowed === '*') return true
+  return allowed.includes(origin)
+}
+
+/**
  * Rate limiting helper for preventing abuse
  */
 export class RateLimiter {

--- a/src/stores/memory-session-store.ts
+++ b/src/stores/memory-session-store.ts
@@ -22,6 +22,13 @@ export class MemorySessionStore implements SessionStore {
     this.messageHistory.set(metadata.id, [])
   }
 
+  async update (metadata: SessionMetadata): Promise<void> {
+    if (!this.sessions.has(metadata.id)) {
+      return
+    }
+    this.sessions.set(metadata.id, { ...metadata })
+  }
+
   async get (sessionId: string): Promise<SessionMetadata | null> {
     const session = this.sessions.get(sessionId)
     return session ? { ...session } : null

--- a/src/stores/memory-session-store.ts
+++ b/src/stores/memory-session-store.ts
@@ -23,10 +23,17 @@ export class MemorySessionStore implements SessionStore {
   }
 
   async update (metadata: SessionMetadata): Promise<void> {
-    if (!this.sessions.has(metadata.id)) {
+    const existing = this.sessions.get(metadata.id)
+    if (!existing) {
       return
     }
-    this.sessions.set(metadata.id, { ...metadata })
+    // Only the negotiated version and activity time are the caller's to change.
+    // Writing the whole record back would roll the event counter back to a stale
+    // value if a concurrent SSE message bumped it between get() and update().
+    existing.lastActivity = metadata.lastActivity
+    if (metadata.protocolVersion !== undefined) {
+      existing.protocolVersion = metadata.protocolVersion
+    }
   }
 
   async get (sessionId: string): Promise<SessionMetadata | null> {

--- a/src/stores/memory-task-store.ts
+++ b/src/stores/memory-task-store.ts
@@ -1,0 +1,94 @@
+import type { TaskStatus } from '../schema.ts'
+import type { TaskStore, TaskRecord, TaskOutcome } from './task-store.ts'
+import { canTransition, isTerminal, taskHasExpired } from './task-store.ts'
+
+/**
+ * In-process task store for single-instance deployments.
+ *
+ * Expired tasks are treated as absent on read and swept lazily, so a task never
+ * outlives its ttl even if `cleanup()` has not run recently.
+ */
+export class MemoryTaskStore implements TaskStore {
+  private tasks = new Map<string, TaskRecord>()
+  private readonly maxTasks: number
+
+  constructor (maxTasks: number = 1000) {
+    this.maxTasks = maxTasks
+  }
+
+  async create (task: TaskRecord): Promise<void> {
+    if (this.tasks.size >= this.maxTasks) {
+      await this.cleanup()
+    }
+    if (this.tasks.size >= this.maxTasks) {
+      throw new Error(`Task limit reached (${this.maxTasks})`)
+    }
+    this.tasks.set(task.taskId, { ...task })
+  }
+
+  async get (taskId: string): Promise<TaskRecord | null> {
+    const task = this.tasks.get(taskId)
+    if (!task) return null
+    if (taskHasExpired(task)) {
+      this.tasks.delete(taskId)
+      return null
+    }
+    return { ...task }
+  }
+
+  async updateStatus (
+    taskId: string,
+    status: TaskStatus,
+    options: { statusMessage?: string, outcome?: TaskOutcome } = {}
+  ): Promise<TaskRecord | null> {
+    const task = await this.get(taskId)
+    if (!task) return null
+
+    if (task.status !== status) {
+      if (isTerminal(task.status)) {
+        throw new Error(`Task ${taskId} is already in terminal status '${task.status}'`)
+      }
+      if (!canTransition(task.status, status)) {
+        throw new Error(`Invalid task transition '${task.status}' -> '${status}'`)
+      }
+    }
+
+    const updated: TaskRecord = {
+      ...task,
+      status,
+      lastUpdatedAt: new Date().toISOString()
+    }
+    if (options.statusMessage !== undefined) {
+      updated.statusMessage = options.statusMessage
+    }
+    if (options.outcome !== undefined) {
+      updated.outcome = options.outcome
+    }
+
+    this.tasks.set(taskId, updated)
+    return { ...updated }
+  }
+
+  async list (authSubject?: string): Promise<TaskRecord[]> {
+    const results: TaskRecord[] = []
+    for (const task of this.tasks.values()) {
+      if (taskHasExpired(task)) continue
+      // Tasks bound to a subject are only ever visible to that subject
+      if (task.authSubject !== authSubject) continue
+      results.push({ ...task })
+    }
+    return results.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+  }
+
+  async delete (taskId: string): Promise<void> {
+    this.tasks.delete(taskId)
+  }
+
+  async cleanup (): Promise<void> {
+    for (const [taskId, task] of this.tasks.entries()) {
+      if (taskHasExpired(task)) {
+        this.tasks.delete(taskId)
+      }
+    }
+  }
+}

--- a/src/stores/memory-task-store.ts
+++ b/src/stores/memory-task-store.ts
@@ -41,8 +41,15 @@ export class MemoryTaskStore implements TaskStore {
     status: TaskStatus,
     options: { statusMessage?: string, outcome?: TaskOutcome } = {}
   ): Promise<TaskRecord | null> {
-    const task = await this.get(taskId)
-    if (!task) return null
+    // Read straight from the map with no intervening await, so the terminal
+    // check and the write cannot interleave with a concurrent updateStatus.
+    // A separate `await this.get()` here would open a window in which a cancel
+    // and a completion both read `working` and each overwrite the other.
+    const task = this.tasks.get(taskId)
+    if (!task || taskHasExpired(task)) {
+      this.tasks.delete(taskId)
+      return null
+    }
 
     if (task.status !== status) {
       if (isTerminal(task.status)) {

--- a/src/stores/redis-session-store.ts
+++ b/src/stores/redis-session-store.ts
@@ -51,20 +51,20 @@ export class RedisSessionStore implements SessionStore {
   async update (metadata: SessionMetadata): Promise<void> {
     const sessionKey = `session:${metadata.id}`
 
+    // Persist only what the caller owns: the negotiated version and activity
+    // time. Writing eventId/lastEventId here would roll the SSE counter back to
+    // a stale value if addMessage bumped it between the caller's get() and now.
     const sessionData: Record<string, string> = {
-      eventId: metadata.eventId.toString(),
-      lastEventId: metadata.lastEventId || '',
       lastActivity: metadata.lastActivity.toISOString()
     }
-
     if (metadata.protocolVersion) {
       sessionData.protocolVersion = metadata.protocolVersion
     }
 
     // Check-then-write must be atomic: a separate EXISTS followed by HSET would
-    // recreate a session that expired in between, leaving it with no TTL and only
-    // the partial fields written here. The script skips the write when the key is
-    // already gone, so an expired session stays expired and keeps its existing TTL.
+    // recreate a session that expired in between, leaving it with no TTL. The
+    // script skips the write when the key is gone, so an expired session stays
+    // expired; HSET does not touch the TTL, so the original expiry is preserved.
     await this.redis.eval(
       `if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
        redis.call('HSET', KEYS[1], unpack(ARGV))

--- a/src/stores/redis-session-store.ts
+++ b/src/stores/redis-session-store.ts
@@ -51,11 +51,6 @@ export class RedisSessionStore implements SessionStore {
   async update (metadata: SessionMetadata): Promise<void> {
     const sessionKey = `session:${metadata.id}`
 
-    // Only touch sessions that still exist; an expired session must stay expired
-    if (await this.redis.exists(sessionKey) === 0) {
-      return
-    }
-
     const sessionData: Record<string, string> = {
       eventId: metadata.eventId.toString(),
       lastEventId: metadata.lastEventId || '',
@@ -66,7 +61,18 @@ export class RedisSessionStore implements SessionStore {
       sessionData.protocolVersion = metadata.protocolVersion
     }
 
-    await this.redis.hset(sessionKey, sessionData)
+    // Check-then-write must be atomic: a separate EXISTS followed by HSET would
+    // recreate a session that expired in between, leaving it with no TTL and only
+    // the partial fields written here. The script skips the write when the key is
+    // already gone, so an expired session stays expired and keeps its existing TTL.
+    await this.redis.eval(
+      `if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
+       redis.call('HSET', KEYS[1], unpack(ARGV))
+       return 1`,
+      1,
+      sessionKey,
+      ...Object.entries(sessionData).flat()
+    )
   }
 
   async get (sessionId: string): Promise<SessionMetadata | null> {

--- a/src/stores/redis-session-store.ts
+++ b/src/stores/redis-session-store.ts
@@ -22,6 +22,10 @@ export class RedisSessionStore implements SessionStore {
       lastActivity: metadata.lastActivity.toISOString()
     }
 
+    if (metadata.protocolVersion) {
+      sessionData.protocolVersion = metadata.protocolVersion
+    }
+
     // Add authorization context if present
     if (metadata.authorization) {
       sessionData.authorization = JSON.stringify(metadata.authorization)
@@ -44,6 +48,27 @@ export class RedisSessionStore implements SessionStore {
     }
   }
 
+  async update (metadata: SessionMetadata): Promise<void> {
+    const sessionKey = `session:${metadata.id}`
+
+    // Only touch sessions that still exist; an expired session must stay expired
+    if (await this.redis.exists(sessionKey) === 0) {
+      return
+    }
+
+    const sessionData: Record<string, string> = {
+      eventId: metadata.eventId.toString(),
+      lastEventId: metadata.lastEventId || '',
+      lastActivity: metadata.lastActivity.toISOString()
+    }
+
+    if (metadata.protocolVersion) {
+      sessionData.protocolVersion = metadata.protocolVersion
+    }
+
+    await this.redis.hset(sessionKey, sessionData)
+  }
+
   async get (sessionId: string): Promise<SessionMetadata | null> {
     const sessionKey = `session:${sessionId}`
     const result = await this.redis.hgetall(sessionKey)
@@ -57,7 +82,8 @@ export class RedisSessionStore implements SessionStore {
       eventId: parseInt(result.eventId, 10),
       lastEventId: result.lastEventId || undefined,
       createdAt: new Date(result.createdAt),
-      lastActivity: new Date(result.lastActivity)
+      lastActivity: new Date(result.lastActivity),
+      protocolVersion: result.protocolVersion || undefined
     }
 
     // Parse authorization context if present

--- a/src/stores/redis-task-store.ts
+++ b/src/stores/redis-task-store.ts
@@ -31,7 +31,14 @@ export class RedisTaskStore implements TaskStore {
 
   async create (task: TaskRecord): Promise<void> {
     const key = this.key(task.taskId)
-    await this.redis.set(key, JSON.stringify(task), 'EX', this.expirySeconds(task))
+    // A null ttl means unlimited retention (matching taskHasExpired and the
+    // memory store), so write the key without an expiry rather than falling back
+    // to the default and silently expiring it.
+    if (task.ttl === null) {
+      await this.redis.set(key, JSON.stringify(task))
+    } else {
+      await this.redis.set(key, JSON.stringify(task), 'EX', this.expirySeconds(task))
+    }
     // Index membership lets `list` enumerate without a keyspace scan; stale ids
     // are pruned on read, since the task keys expire independently.
     await this.redis.zadd(TASK_INDEX_KEY, new Date(task.createdAt).getTime(), task.taskId)

--- a/src/stores/redis-task-store.ts
+++ b/src/stores/redis-task-store.ts
@@ -87,9 +87,30 @@ export class RedisTaskStore implements TaskStore {
       updated.outcome = options.outcome
     }
 
-    // KEEPTTL: retention is measured from creation, so a status change must not
-    // extend the task's lifetime.
-    await this.redis.set(this.key(taskId), JSON.stringify(updated), 'KEEPTTL')
+    // The read above and this write are two round trips, so a concurrent write
+    // can slip between them. Re-check the stored status atomically in Lua and
+    // refuse if it has since become terminal, so a cancel and a completion
+    // racing on the same task cannot overwrite each other — the spec requires a
+    // cancelled task to stay cancelled. KEEPTTL preserves retention-from-creation.
+    const result = await this.redis.eval(
+      `local raw = redis.call('GET', KEYS[1])
+       if not raw then return false end
+       local ok, cur = pcall(cjson.decode, raw)
+       if not ok then return false end
+       local s = cur.status
+       if s == 'completed' or s == 'failed' or s == 'cancelled' then return s end
+       redis.call('SET', KEYS[1], ARGV[1], 'KEEPTTL')
+       return 'OK'`,
+      1,
+      this.key(taskId),
+      JSON.stringify(updated)
+    )
+
+    if (result === null) return null
+    if (result !== 'OK') {
+      // A terminal status was written concurrently; `result` is that status
+      throw new Error(`Task ${taskId} is already in terminal status '${result}'`)
+    }
     return updated
   }
 

--- a/src/stores/redis-task-store.ts
+++ b/src/stores/redis-task-store.ts
@@ -1,0 +1,125 @@
+import type { Redis } from 'ioredis'
+import type { TaskStatus } from '../schema.ts'
+import type { TaskStore, TaskRecord, TaskOutcome } from './task-store.ts'
+import { canTransition, isTerminal, taskHasExpired } from './task-store.ts'
+
+const TASK_KEY_PREFIX = 'mcp:task:'
+const TASK_INDEX_KEY = 'mcp:tasks'
+
+/**
+ * Redis-backed task store, so tasks created on one instance can be polled from
+ * any other. Task retention is enforced with Redis key expiry, which means an
+ * expired task disappears without us having to sweep it.
+ */
+export class RedisTaskStore implements TaskStore {
+  private redis: Redis
+  private readonly defaultTtlMs: number
+
+  constructor (options: { redis: Redis, defaultTtlMs?: number }) {
+    this.redis = options.redis
+    this.defaultTtlMs = options.defaultTtlMs ?? 3600_000
+  }
+
+  private key (taskId: string): string {
+    return `${TASK_KEY_PREFIX}${taskId}`
+  }
+
+  private expirySeconds (task: TaskRecord): number {
+    const ttl = task.ttl ?? this.defaultTtlMs
+    return Math.max(1, Math.ceil(ttl / 1000))
+  }
+
+  async create (task: TaskRecord): Promise<void> {
+    const key = this.key(task.taskId)
+    await this.redis.set(key, JSON.stringify(task), 'EX', this.expirySeconds(task))
+    // Index membership lets `list` enumerate without a keyspace scan; stale ids
+    // are pruned on read, since the task keys expire independently.
+    await this.redis.zadd(TASK_INDEX_KEY, new Date(task.createdAt).getTime(), task.taskId)
+  }
+
+  async get (taskId: string): Promise<TaskRecord | null> {
+    const raw = await this.redis.get(this.key(taskId))
+    if (!raw) {
+      await this.redis.zrem(TASK_INDEX_KEY, taskId)
+      return null
+    }
+
+    let task: TaskRecord
+    try {
+      task = JSON.parse(raw)
+    } catch {
+      return null
+    }
+
+    if (taskHasExpired(task)) {
+      await this.delete(taskId)
+      return null
+    }
+    return task
+  }
+
+  async updateStatus (
+    taskId: string,
+    status: TaskStatus,
+    options: { statusMessage?: string, outcome?: TaskOutcome } = {}
+  ): Promise<TaskRecord | null> {
+    const task = await this.get(taskId)
+    if (!task) return null
+
+    if (task.status !== status) {
+      if (isTerminal(task.status)) {
+        throw new Error(`Task ${taskId} is already in terminal status '${task.status}'`)
+      }
+      if (!canTransition(task.status, status)) {
+        throw new Error(`Invalid task transition '${task.status}' -> '${status}'`)
+      }
+    }
+
+    const updated: TaskRecord = {
+      ...task,
+      status,
+      lastUpdatedAt: new Date().toISOString()
+    }
+    if (options.statusMessage !== undefined) {
+      updated.statusMessage = options.statusMessage
+    }
+    if (options.outcome !== undefined) {
+      updated.outcome = options.outcome
+    }
+
+    // KEEPTTL: retention is measured from creation, so a status change must not
+    // extend the task's lifetime.
+    await this.redis.set(this.key(taskId), JSON.stringify(updated), 'KEEPTTL')
+    return updated
+  }
+
+  async list (authSubject?: string): Promise<TaskRecord[]> {
+    const ids = await this.redis.zrevrange(TASK_INDEX_KEY, 0, -1)
+    const results: TaskRecord[] = []
+
+    for (const id of ids) {
+      const task = await this.get(id)
+      if (!task) continue
+      if (task.authSubject !== authSubject) continue
+      results.push(task)
+    }
+
+    return results
+  }
+
+  async delete (taskId: string): Promise<void> {
+    await this.redis.del(this.key(taskId))
+    await this.redis.zrem(TASK_INDEX_KEY, taskId)
+  }
+
+  async cleanup (): Promise<void> {
+    // Task keys expire on their own; this only prunes the index of ids whose
+    // task key is already gone.
+    const ids = await this.redis.zrange(TASK_INDEX_KEY, 0, -1)
+    for (const id of ids) {
+      if (await this.redis.exists(this.key(id)) === 0) {
+        await this.redis.zrem(TASK_INDEX_KEY, id)
+      }
+    }
+  }
+}

--- a/src/stores/session-store.ts
+++ b/src/stores/session-store.ts
@@ -7,6 +7,8 @@ export interface SessionMetadata {
   lastEventId?: string
   createdAt: Date
   lastActivity: Date
+  /** Protocol revision agreed during `initialize`, if the handshake has happened */
+  protocolVersion?: string
   authSession?: any // OAuth session data (legacy - for Phase 2 compatibility)
 
   // Enhanced authorization context
@@ -16,6 +18,11 @@ export interface SessionMetadata {
 
 export interface SessionStore {
   create(metadata: SessionMetadata): Promise<void>
+  /**
+   * Persist changes to an existing session without touching its message history.
+   * A no-op when the session is gone.
+   */
+  update(metadata: SessionMetadata): Promise<void>
   get(sessionId: string): Promise<SessionMetadata | null>
   delete(sessionId: string): Promise<void>
   cleanup(): Promise<void>

--- a/src/stores/task-store.ts
+++ b/src/stores/task-store.ts
@@ -1,0 +1,117 @@
+import type { Task, TaskStatus, JSONRPCResultResponse, JSONRPCErrorResponse } from '../schema.ts'
+
+/**
+ * The final outcome of a task-augmented request, stored verbatim so that
+ * `tasks/result` can return exactly what the underlying request would have
+ * returned — success or JSON-RPC error.
+ */
+export type TaskOutcome = JSONRPCResultResponse | JSONRPCErrorResponse
+
+export interface TaskRecord extends Task {
+  /**
+   * Authorization subject this task belongs to, when the deployment can identify
+   * requestors. `tasks/get`, `tasks/result` and `tasks/cancel` must refuse tasks
+   * belonging to a different context.
+   */
+  authSubject?: string
+  /** The method of the request the task wraps, e.g. `tools/call` */
+  method: string
+  /** Terminal outcome, present once the task reaches completed/failed/cancelled */
+  outcome?: TaskOutcome
+}
+
+/**
+ * Which status transitions the spec permits. Terminal states are absent because
+ * they can never transition again.
+ */
+const ALLOWED_TRANSITIONS: Record<string, TaskStatus[]> = {
+  working: ['input_required', 'completed', 'failed', 'cancelled'],
+  input_required: ['working', 'completed', 'failed', 'cancelled']
+}
+
+export const TERMINAL_STATUSES: TaskStatus[] = ['completed', 'failed', 'cancelled']
+
+export function isTerminal (status: TaskStatus): boolean {
+  return TERMINAL_STATUSES.includes(status)
+}
+
+export function canTransition (from: TaskStatus, to: TaskStatus): boolean {
+  return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false
+}
+
+export interface TaskStore {
+  create(task: TaskRecord): Promise<void>
+  get(taskId: string): Promise<TaskRecord | null>
+  /**
+   * Move a task to a new status, rejecting transitions the spec forbids.
+   * Returns the updated record, or null if the task is gone.
+   * @throws if the transition is not allowed
+   */
+  updateStatus(taskId: string, status: TaskStatus, options?: { statusMessage?: string, outcome?: TaskOutcome }): Promise<TaskRecord | null>
+  /** Tasks visible to the given authorization subject, newest first */
+  list(authSubject?: string): Promise<TaskRecord[]>
+  delete(taskId: string): Promise<void>
+  /** Drop tasks whose ttl has elapsed */
+  cleanup(): Promise<void>
+  close?(): Promise<void>
+}
+
+/**
+ * Wake anyone blocked in `tasks/result` when a task reaches a terminal state.
+ * Kept separate from the store so both backends can share it: the waiters only
+ * ever live in the process handling that particular `tasks/result` request.
+ */
+export class TaskWaiters {
+  private waiters = new Map<string, Set<(task: TaskRecord) => void>>()
+
+  wait (taskId: string, signal?: AbortSignal): Promise<TaskRecord> {
+    return new Promise((resolve, reject) => {
+      const resolveAndCleanup = (task: TaskRecord) => {
+        this.remove(taskId, resolveAndCleanup)
+        resolve(task)
+      }
+
+      let set = this.waiters.get(taskId)
+      if (!set) {
+        set = new Set()
+        this.waiters.set(taskId, set)
+      }
+      set.add(resolveAndCleanup)
+
+      signal?.addEventListener('abort', () => {
+        this.remove(taskId, resolveAndCleanup)
+        reject(new Error('aborted'))
+      }, { once: true })
+    })
+  }
+
+  notify (task: TaskRecord): void {
+    const set = this.waiters.get(task.taskId)
+    if (!set) return
+    for (const waiter of [...set]) {
+      waiter(task)
+    }
+  }
+
+  private remove (taskId: string, waiter: (task: TaskRecord) => void): void {
+    const set = this.waiters.get(taskId)
+    if (!set) return
+    set.delete(waiter)
+    if (set.size === 0) {
+      this.waiters.delete(taskId)
+    }
+  }
+}
+
+export function taskHasExpired (task: TaskRecord, now: number = Date.now()): boolean {
+  if (task.ttl === null || task.ttl === undefined) return false
+  return now - new Date(task.createdAt).getTime() > task.ttl
+}
+
+/**
+ * Strip storage-only fields so a record can go on the wire as a spec `Task`.
+ */
+export function toWireTask (task: TaskRecord): Task {
+  const { authSubject, method, outcome, ...wire } = task
+  return wire
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,17 @@ export interface MCPPluginOptions {
    */
   enableTasks?: boolean
   /**
+   * Retention for a task whose creator did not request a `ttl`, in milliseconds
+   * (default 60000). Raise it when tools can run longer than a minute, so their
+   * tasks do not expire before completing.
+   */
+  taskDefaultTtlMs?: number
+  /**
+   * Ceiling on task retention, in milliseconds (default 3600000). A requested
+   * `ttl` above this is capped, so a client cannot pin resources indefinitely.
+   */
+  taskMaxTtlMs?: number
+  /**
    * Origins accepted on the MCP endpoints, to prevent DNS rebinding attacks.
    * Omit to disable validation (non-browser deployments), pass `'*'` or `true`
    * to accept any origin, or list exact origins to allow.

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,12 @@ import type {
   Tool,
   Resource,
   Prompt,
-  ElicitRequest,
+  ElicitRequestFormParams,
   RequestId
 } from './schema.ts'
 import type { Static, TSchema, TObject, TString } from '@sinclair/typebox'
 import type { AuthorizationConfig, AuthorizationContext } from './types/auth-types.ts'
+import type { AllowedOrigins } from './security.ts'
 
 // Context interface for all handler types
 export interface HandlerContext {
@@ -121,8 +122,27 @@ declare module 'fastify' {
     mcpElicit: (
       sessionId: string,
       message: string,
-      requestedSchema: ElicitRequest['params']['requestedSchema'],
+      requestedSchema: ElicitRequestFormParams['requestedSchema'],
       requestId?: RequestId
+    ) => Promise<boolean>
+
+    /**
+     * Send a URL mode elicitation request. Resolves to the elicitation id on
+     * success (use it to correlate the later completion notification), or null
+     * if the request could not be sent.
+     */
+    mcpElicitUrl: (
+      sessionId: string,
+      message: string,
+      url: string,
+      elicitationId?: string,
+      requestId?: RequestId
+    ) => Promise<string | null>
+
+    /** Signal that an out-of-band URL elicitation has completed */
+    mcpNotifyElicitationComplete: (
+      sessionId: string,
+      elicitationId: string
     ) => Promise<boolean>
 
     // Resource subscription handler setters
@@ -157,6 +177,23 @@ export interface MCPPluginOptions {
   capabilities?: ServerCapabilities
   instructions?: string
   enableSSE?: boolean
+  /**
+   * Close an SSE stream after this many milliseconds so the client falls back to
+   * polling and reconnects with `Last-Event-ID` (SEP-1699). Omit to keep streams
+   * open indefinitely, which stays valid.
+   */
+  sseMaxConnectionMs?: number
+  /**
+   * Enable task-augmented execution (2025-11-25, experimental). Tools opt in
+   * individually via `execution.taskSupport`.
+   */
+  enableTasks?: boolean
+  /**
+   * Origins accepted on the MCP endpoints, to prevent DNS rebinding attacks.
+   * Omit to disable validation (non-browser deployments), pass `'*'` or `true`
+   * to accept any origin, or list exact origins to allow.
+   */
+  allowedOrigins?: AllowedOrigins
   sessionStore?: 'memory' | 'redis'
   messageBroker?: 'memory' | 'redis'
   redis?: {

--- a/src/types/auth-types.ts
+++ b/src/types/auth-types.ts
@@ -109,6 +109,13 @@ export type AuthorizationConfig =
     resourceUri: string
     /** Paths to exclude from authorization (e.g., health checks). Supports string prefix or RegExp. */
     excludedPaths?: (string | RegExp)[]
+    /**
+     * Scopes a token must carry to reach the MCP endpoints. A token that is
+     * valid but missing any of these is answered with 403 and a
+     * `WWW-Authenticate: Bearer error="insufficient_scope"` challenge naming the
+     * scopes needed, so the client can ask the user to grant them (SEP-835).
+     */
+    requiredScopes?: string[]
     tokenValidation: {
       introspectionEndpoint?: string
       jwksUri?: string
@@ -128,6 +135,11 @@ export type AuthorizationConfig =
       resourceUri?: string
       scopes?: string[]
       dynamicRegistration?: boolean
+      /**
+       * Use an OAuth Client ID Metadata Document as the client identifier
+       * (SEP-991) instead of registering with the authorization server.
+       */
+      clientIdMetadataDocument?: boolean | { path?: string }
     }
     /**
      * DCR hooks for custom request/response processing.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,7 +4,7 @@ import Fastify from 'fastify'
 import mcpPlugin from '../src/index.ts'
 import type {
   JSONRPCRequest,
-  JSONRPCResponse,
+  JSONRPCResultResponse,
   JSONRPCError,
   JSONRPCNotification,
   InitializeResult,
@@ -76,7 +76,7 @@ describe('MCP Fastify Plugin', () => {
       })
 
       t.assert.strictEqual(response.statusCode, 200)
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       t.assert.strictEqual(body.jsonrpc, JSONRPC_VERSION)
       t.assert.strictEqual(body.id, 1)
 
@@ -108,7 +108,7 @@ describe('MCP Fastify Plugin', () => {
       })
 
       t.assert.strictEqual(response.statusCode, 200)
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       t.assert.strictEqual(body.jsonrpc, JSONRPC_VERSION)
       t.assert.strictEqual(body.id, 2)
       t.assert.deepStrictEqual(body.result, {})
@@ -134,7 +134,7 @@ describe('MCP Fastify Plugin', () => {
       })
 
       t.assert.strictEqual(response.statusCode, 200)
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as ListToolsResult
       t.assert.ok(Array.isArray(result.tools))
       t.assert.strictEqual(result.tools.length, 0)
@@ -160,7 +160,7 @@ describe('MCP Fastify Plugin', () => {
       })
 
       t.assert.strictEqual(response.statusCode, 200)
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as ListResourcesResult
       t.assert.ok(Array.isArray(result.resources))
       t.assert.strictEqual(result.resources.length, 0)
@@ -186,7 +186,7 @@ describe('MCP Fastify Plugin', () => {
       })
 
       t.assert.strictEqual(response.statusCode, 200)
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as ListPromptsResult
       t.assert.ok(Array.isArray(result.prompts))
       t.assert.strictEqual(result.prompts.length, 0)
@@ -481,7 +481,7 @@ describe('MCP Fastify Plugin', () => {
 
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.strictEqual(response.headers['content-type'], 'application/json; charset=utf-8')
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       t.assert.strictEqual(body.jsonrpc, JSONRPC_VERSION)
       t.assert.strictEqual(body.id, 1)
     })
@@ -554,7 +554,7 @@ describe('MCP Fastify Plugin', () => {
         payload: request
       })
 
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as ListToolsResult
       t.assert.strictEqual(result.tools.length, 1)
       t.assert.strictEqual(result.tools[0].name, 'test-tool')
@@ -589,7 +589,7 @@ describe('MCP Fastify Plugin', () => {
         payload: request
       })
 
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as ListResourcesResult
       t.assert.strictEqual(result.resources.length, 1)
       t.assert.strictEqual(result.resources[0].name, 'Test Resource')
@@ -623,7 +623,7 @@ describe('MCP Fastify Plugin', () => {
         payload: request
       })
 
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as ListPromptsResult
       t.assert.strictEqual(result.prompts.length, 1)
       t.assert.strictEqual(result.prompts[0].name, 'test-prompt')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -48,6 +48,29 @@ describe('MCP Fastify Plugin', () => {
   })
 
   describe('MCP Protocol Handlers', () => {
+    test('rejects a JSON-RPC batch with -32600 rather than a 500', async (t: TestContext) => {
+      const app = Fastify()
+      t.after(() => app.close())
+      await app.register(mcpPlugin)
+      await app.ready()
+
+      // Batching was removed in 2025-06-18; an array body must be refused
+      // gracefully as a protocol error, not surface as an opaque HTTP 500.
+      const response = await app.inject({
+        method: 'POST',
+        url: '/mcp',
+        payload: [
+          { jsonrpc: JSONRPC_VERSION, id: 1, method: 'ping', params: {} },
+          { jsonrpc: JSONRPC_VERSION, id: 2, method: 'ping', params: {} }
+        ]
+      })
+
+      t.assert.strictEqual(response.statusCode, 200)
+      const body = response.json() as { error: { code: number }, id: unknown }
+      t.assert.strictEqual(body.error.code, -32600)
+      t.assert.strictEqual(body.id, null)
+    })
+
     test('should handle initialize request', async (t: TestContext) => {
       const app = Fastify()
       t.after(() => app.close())

--- a/test/protocol-negotiation.test.ts
+++ b/test/protocol-negotiation.test.ts
@@ -1,0 +1,271 @@
+import { test, describe } from 'node:test'
+import type { TestContext } from 'node:test'
+import Fastify from 'fastify'
+import mcpPlugin from '../src/index.ts'
+import type { JSONRPCRequest, InitializeResult } from '../src/schema.ts'
+import {
+  JSONRPC_VERSION,
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+} from '../src/schema.ts'
+import { negotiateProtocolVersion } from '../src/handlers.ts'
+import { isOriginAllowed } from '../src/security.ts'
+import { createTestAuthConfig } from './auth-test-utils.ts'
+
+function initializeRequest (protocolVersion?: string): JSONRPCRequest {
+  const params: Record<string, unknown> = {
+    capabilities: {},
+    clientInfo: { name: 'test-client', version: '1.0.0' }
+  }
+  if (protocolVersion !== undefined) {
+    params.protocolVersion = protocolVersion
+  }
+  return { jsonrpc: JSONRPC_VERSION, id: 1, method: 'initialize', params }
+}
+
+describe('protocol version negotiation', () => {
+  test('negotiateProtocolVersion echoes any supported version', (t: TestContext) => {
+    for (const version of SUPPORTED_PROTOCOL_VERSIONS) {
+      t.assert.strictEqual(negotiateProtocolVersion(version), version)
+    }
+  })
+
+  test('negotiateProtocolVersion falls back to latest for unknown input', (t: TestContext) => {
+    t.assert.strictEqual(negotiateProtocolVersion('1999-01-01'), LATEST_PROTOCOL_VERSION)
+    t.assert.strictEqual(negotiateProtocolVersion(undefined), LATEST_PROTOCOL_VERSION)
+    t.assert.strictEqual(negotiateProtocolVersion(42), LATEST_PROTOCOL_VERSION)
+    t.assert.strictEqual(negotiateProtocolVersion(null), LATEST_PROTOCOL_VERSION)
+  })
+
+  test('initialize echoes a supported version requested by the client', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: initializeRequest('2025-03-26')
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    const result = response.json().result as InitializeResult
+    t.assert.strictEqual(result.protocolVersion, '2025-03-26')
+  })
+
+  test('initialize offers the latest version when the client asks for an unsupported one', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: initializeRequest('2099-12-31')
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    const result = response.json().result as InitializeResult
+    t.assert.strictEqual(result.protocolVersion, LATEST_PROTOCOL_VERSION)
+  })
+
+  test('initialize offers the latest version when the client sends none', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: initializeRequest()
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    const result = response.json().result as InitializeResult
+    t.assert.strictEqual(result.protocolVersion, LATEST_PROTOCOL_VERSION)
+  })
+
+  test('the negotiated version is persisted on the session', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { enableSSE: true })
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: initializeRequest('2025-03-26')
+    })
+
+    const sessionId = response.headers['mcp-session-id'] as string
+    t.assert.ok(sessionId, 'expected a session to be created')
+
+    // A follow-up request on the same session must still see the agreed version
+    const ping = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-03-26' },
+      payload: { jsonrpc: JSONRPC_VERSION, id: 2, method: 'ping', params: {} }
+    })
+    t.assert.strictEqual(ping.statusCode, 200)
+  })
+})
+
+describe('MCP-Protocol-Version header validation', () => {
+  test('accepts a supported version header', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION },
+      payload: { jsonrpc: JSONRPC_VERSION, id: 1, method: 'ping', params: {} }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+  })
+
+  test('rejects an unsupported version header with 400', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { 'mcp-protocol-version': '1999-01-01' },
+      payload: { jsonrpc: JSONRPC_VERSION, id: 1, method: 'ping', params: {} }
+    })
+
+    t.assert.strictEqual(response.statusCode, 400)
+    t.assert.deepStrictEqual(response.json().supported, [...SUPPORTED_PROTOCOL_VERSIONS])
+  })
+
+  test('a missing header is allowed and implies the pre-header revision', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+
+    let seen: string | undefined
+    app.addHook('preHandler', async (request) => {
+      seen = (request as any).mcpProtocolVersion
+    })
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: { jsonrpc: JSONRPC_VERSION, id: 1, method: 'ping', params: {} }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(seen, DEFAULT_NEGOTIATED_PROTOCOL_VERSION)
+  })
+
+  test('the header is not enforced on the well-known routes', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { authorization: createTestAuthConfig() })
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/.well-known/oauth-protected-resource',
+      headers: { 'mcp-protocol-version': '1999-01-01' }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+  })
+})
+
+describe('Origin validation', () => {
+  test('isOriginAllowed honours every configuration shape', (t: TestContext) => {
+    // Unconfigured: validation off
+    t.assert.strictEqual(isOriginAllowed('https://evil.example', undefined), true)
+    // Wildcards
+    t.assert.strictEqual(isOriginAllowed('https://evil.example', '*'), true)
+    t.assert.strictEqual(isOriginAllowed('https://evil.example', true), true)
+    // Allow-list
+    t.assert.strictEqual(isOriginAllowed('https://app.example', ['https://app.example']), true)
+    t.assert.strictEqual(isOriginAllowed('https://evil.example', ['https://app.example']), false)
+    // No Origin header at all: not a browser, so not a rebinding risk
+    t.assert.strictEqual(isOriginAllowed(undefined, ['https://app.example']), true)
+  })
+
+  test('rejects a disallowed Origin with 403', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { allowedOrigins: ['https://app.example'] })
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { origin: 'https://evil.example' },
+      payload: { jsonrpc: JSONRPC_VERSION, id: 1, method: 'ping', params: {} }
+    })
+
+    t.assert.strictEqual(response.statusCode, 403)
+  })
+
+  test('accepts an allow-listed Origin', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { allowedOrigins: ['https://app.example'] })
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { origin: 'https://app.example' },
+      payload: { jsonrpc: JSONRPC_VERSION, id: 1, method: 'ping', params: {} }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+  })
+
+  test('accepts any Origin when validation is not configured', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { origin: 'https://anything.example' },
+      payload: { jsonrpc: JSONRPC_VERSION, id: 1, method: 'ping', params: {} }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+  })
+
+  test('Origin validation covers GET and DELETE too', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { enableSSE: true, allowedOrigins: ['https://app.example'] })
+    await app.ready()
+
+    const get = await app.inject({
+      method: 'GET',
+      url: '/mcp',
+      headers: { origin: 'https://evil.example', accept: 'text/event-stream' }
+    })
+    t.assert.strictEqual(get.statusCode, 403)
+
+    const del = await app.inject({
+      method: 'DELETE',
+      url: '/mcp',
+      headers: { origin: 'https://evil.example' }
+    })
+    t.assert.strictEqual(del.statusCode, 403)
+  })
+})

--- a/test/redis-session-store.test.ts
+++ b/test/redis-session-store.test.ts
@@ -263,16 +263,18 @@ describe('RedisSessionStore', () => {
     assert.strictEqual(await redis.exists('session:expiring-session'), 0, 'no key should exist')
   })
 
-  testWithRedis('update preserves the existing TTL', async (redis) => {
+  testWithRedis('update persists the protocol version and preserves TTL and event counter', async (redis) => {
     const store = new RedisSessionStore({ redis, maxMessages: 100 })
 
     await store.create({
       id: 'ttl-session',
-      eventId: 1,
+      eventId: 5,
       createdAt: new Date('2023-01-01T00:00:00.000Z'),
       lastActivity: new Date('2023-01-01T00:00:00.000Z')
     })
 
+    // A stale eventId in the update payload must NOT roll the counter back: the
+    // event counter is owned by addMessage, not update.
     await store.update({
       id: 'ttl-session',
       eventId: 2,
@@ -285,7 +287,7 @@ describe('RedisSessionStore', () => {
     assert.ok(ttl > 3500 && ttl <= 3600, `expected the 1h TTL to persist, got ${ttl}`)
 
     const updated = await store.get('ttl-session')
-    assert.strictEqual(updated?.eventId, 2)
     assert.strictEqual(updated?.protocolVersion, '2025-11-25')
+    assert.strictEqual(updated?.eventId, 5, 'the event counter must not be rolled back by update')
   })
 })

--- a/test/redis-session-store.test.ts
+++ b/test/redis-session-store.test.ts
@@ -238,4 +238,54 @@ describe('RedisSessionStore', () => {
     const history = await store.getMessagesFrom('non-existent-session', '0')
     assert.strictEqual(history.length, 0)
   })
+
+  testWithRedis('update does not recreate a session that expired first', async (redis) => {
+    const store = new RedisSessionStore({ redis, maxMessages: 100 })
+
+    const metadata: SessionMetadata = {
+      id: 'expiring-session',
+      eventId: 1,
+      createdAt: new Date('2023-01-01T00:00:00.000Z'),
+      lastActivity: new Date('2023-01-01T00:00:00.000Z'),
+      protocolVersion: '2025-11-25'
+    }
+    await store.create(metadata)
+
+    // Simulate the session's TTL elapsing between the existence check and the
+    // write. A non-atomic check-then-write would resurrect it here without a TTL.
+    await redis.del('session:expiring-session')
+
+    metadata.eventId = 2
+    metadata.lastActivity = new Date('2023-01-01T00:05:00.000Z')
+    await store.update(metadata)
+
+    assert.strictEqual(await store.get('expiring-session'), null, 'session must not be recreated')
+    assert.strictEqual(await redis.exists('session:expiring-session'), 0, 'no key should exist')
+  })
+
+  testWithRedis('update preserves the existing TTL', async (redis) => {
+    const store = new RedisSessionStore({ redis, maxMessages: 100 })
+
+    await store.create({
+      id: 'ttl-session',
+      eventId: 1,
+      createdAt: new Date('2023-01-01T00:00:00.000Z'),
+      lastActivity: new Date('2023-01-01T00:00:00.000Z')
+    })
+
+    await store.update({
+      id: 'ttl-session',
+      eventId: 2,
+      createdAt: new Date('2023-01-01T00:00:00.000Z'),
+      lastActivity: new Date('2023-01-01T00:05:00.000Z'),
+      protocolVersion: '2025-11-25'
+    })
+
+    const ttl = await redis.ttl('session:ttl-session')
+    assert.ok(ttl > 3500 && ttl <= 3600, `expected the 1h TTL to persist, got ${ttl}`)
+
+    const updated = await store.get('ttl-session')
+    assert.strictEqual(updated?.eventId, 2)
+    assert.strictEqual(updated?.protocolVersion, '2025-11-25')
+  })
 })

--- a/test/redis-task-integration.test.ts
+++ b/test/redis-task-integration.test.ts
@@ -98,8 +98,8 @@ describe('Redis task integration (multi-instance)', () => {
     }
     assert.strictEqual(status, 'completed')
 
-    // ...and B can also list it
-    const list = await call(b, 'tasks/list', {})
-    assert.ok(list.result.tasks.some((x: any) => x.taskId === taskId))
+    // B can also read the full result across instances
+    const result = await call(b, 'tasks/result', { taskId })
+    assert.strictEqual(result.result.content[0].text, 'ok')
   })
 })

--- a/test/redis-task-integration.test.ts
+++ b/test/redis-task-integration.test.ts
@@ -1,0 +1,105 @@
+import { describe } from 'node:test'
+import assert from 'node:assert'
+import fastify from 'fastify'
+import { Type } from '@sinclair/typebox'
+import mcpPlugin from '../src/index.ts'
+import { testWithRedis } from './redis-test-utils.ts'
+import { JSONRPC_VERSION, LATEST_PROTOCOL_VERSION } from '../src/schema.ts'
+import type { CreateTaskResult, CallToolResult } from '../src/schema.ts'
+
+async function call (app: any, method: string, params: unknown, id = 1) {
+  const response = await app.inject({
+    method: 'POST',
+    url: '/mcp',
+    headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION },
+    payload: { jsonrpc: JSONRPC_VERSION, id, method, params }
+  })
+  return response.json()
+}
+
+describe('Redis task integration (multi-instance)', () => {
+  testWithRedis('a task created on one instance is retrievable from another', async (redis, t) => {
+    const redisOpts = {
+      host: redis.options.host!,
+      port: redis.options.port!,
+      db: redis.options.db!
+    }
+
+    // Instance A owns the tool and will execute the task.
+    const a = fastify()
+    t.after(() => a.close())
+    await a.register(mcpPlugin, { enableTasks: true, redis: redisOpts })
+    a.mcpAddTool({
+      name: 'slow-add',
+      description: 'Adds two numbers, slowly',
+      inputSchema: Type.Object({ a: Type.Number(), b: Type.Number() }),
+      execution: { taskSupport: 'optional' }
+    } as any, async (params: any): Promise<CallToolResult> => {
+      await new Promise(resolve => setTimeout(resolve, 50))
+      return { content: [{ type: 'text', text: String(params.a + params.b) }] }
+    })
+    await a.ready()
+
+    // Instance B shares the same Redis but has no tool; it only reads the store.
+    const b = fastify()
+    t.after(() => b.close())
+    await b.register(mcpPlugin, { enableTasks: true, redis: redisOpts })
+    await b.ready()
+
+    // Create the task on A
+    const created = await call(a, 'tools/call', {
+      name: 'slow-add',
+      arguments: { a: 40, b: 2 },
+      task: { ttl: 30_000 }
+    })
+    const taskId = (created.result as CreateTaskResult).task.taskId
+    assert.ok(taskId)
+
+    // Ask B for the result. Its in-process waiter will never fire, so this
+    // exercises the polling path against the shared store.
+    const result = await call(b, 'tasks/result', { taskId })
+    assert.strictEqual(result.result.content[0].text, '42')
+  })
+
+  testWithRedis('tasks/get on a second instance sees the terminal state', async (redis, t) => {
+    const redisOpts = {
+      host: redis.options.host!,
+      port: redis.options.port!,
+      db: redis.options.db!
+    }
+
+    const a = fastify()
+    t.after(() => a.close())
+    await a.register(mcpPlugin, { enableTasks: true, redis: redisOpts })
+    a.mcpAddTool({
+      name: 'quick',
+      description: 'Returns at once',
+      inputSchema: Type.Object({}),
+      execution: { taskSupport: 'optional' }
+    } as any, async (): Promise<CallToolResult> => {
+      return { content: [{ type: 'text', text: 'ok' }] }
+    })
+    await a.ready()
+
+    const b = fastify()
+    t.after(() => b.close())
+    await b.register(mcpPlugin, { enableTasks: true, redis: redisOpts })
+    await b.ready()
+
+    const created = await call(a, 'tools/call', { name: 'quick', arguments: {}, task: {} })
+    const taskId = (created.result as CreateTaskResult).task.taskId
+
+    // Poll B until it observes A's completion via the shared store
+    let status = 'working'
+    for (let i = 0; i < 100 && status === 'working'; i++) {
+      const body = await call(b, 'tasks/get', { taskId })
+      status = body.result.status
+      if (status === 'working') await new Promise(resolve => setTimeout(resolve, 10))
+    }
+    assert.strictEqual(status, 'completed')
+
+    // ...and B can also list it
+    const list = await call(b, 'tasks/list', {})
+    assert.ok(list.result.tasks.some((x: any) => x.taskId === taskId))
+  })
+})

--- a/test/redis-task-store.test.ts
+++ b/test/redis-task-store.test.ts
@@ -105,6 +105,14 @@ describe('RedisTaskStore', () => {
     t.assert.ok(after > 0, 'task should still be retained')
   })
 
+  test('a null ttl means unlimited retention, not the default expiry', async (t: TestContext) => {
+    await store.create(record({ ttl: null }))
+
+    // -1 is Redis for "key exists but has no expiry"; the default must not apply
+    t.assert.strictEqual(await redis.ttl('mcp:task:task-1'), -1)
+    t.assert.strictEqual((await store.get('task-1'))?.ttl, null)
+  })
+
   test('treats a task past its ttl as absent', async (t: TestContext) => {
     await store.create(record({ createdAt: new Date(Date.now() - 10_000).toISOString(), ttl: 1_000 }))
     t.assert.strictEqual(await store.get('task-1'), null)

--- a/test/redis-task-store.test.ts
+++ b/test/redis-task-store.test.ts
@@ -1,0 +1,123 @@
+import { test, describe, before, after, beforeEach } from 'node:test'
+import type { TestContext } from 'node:test'
+import type { Redis } from 'ioredis'
+import { createTestRedis, cleanupRedis } from './redis-test-utils.ts'
+import { RedisTaskStore } from '../src/stores/redis-task-store.ts'
+import type { TaskRecord } from '../src/stores/task-store.ts'
+
+function record (overrides: Partial<TaskRecord> = {}): TaskRecord {
+  const now = new Date().toISOString()
+  return {
+    taskId: 'task-1',
+    status: 'working',
+    createdAt: now,
+    lastUpdatedAt: now,
+    ttl: 60_000,
+    method: 'tools/call',
+    ...overrides
+  }
+}
+
+describe('RedisTaskStore', () => {
+  let redis: Redis
+  let store: RedisTaskStore
+
+  before(async () => {
+    redis = await createTestRedis()
+  })
+
+  after(async () => {
+    await cleanupRedis(redis)
+  })
+
+  beforeEach(async () => {
+    await redis.flushdb()
+    store = new RedisTaskStore({ redis })
+  })
+
+  test('round-trips a task', async (t: TestContext) => {
+    await store.create(record({ authSubject: 'user-1' }))
+
+    const task = await store.get('task-1')
+    t.assert.strictEqual(task?.taskId, 'task-1')
+    t.assert.strictEqual(task?.status, 'working')
+    t.assert.strictEqual(task?.authSubject, 'user-1')
+    t.assert.strictEqual(task?.method, 'tools/call')
+  })
+
+  test('returns null for an unknown task', async (t: TestContext) => {
+    t.assert.strictEqual(await store.get('nope'), null)
+  })
+
+  test('records a terminal outcome', async (t: TestContext) => {
+    await store.create(record())
+
+    const outcome = { jsonrpc: '2.0' as const, id: 1, result: { content: [{ type: 'text', text: 'hi' }] } }
+    const updated = await store.updateStatus('task-1', 'completed', { statusMessage: 'ok', outcome })
+
+    t.assert.strictEqual(updated?.status, 'completed')
+    t.assert.strictEqual(updated?.statusMessage, 'ok')
+    t.assert.deepStrictEqual((await store.get('task-1'))?.outcome, outcome)
+  })
+
+  test('rejects transitions out of a terminal status', async (t: TestContext) => {
+    await store.create(record())
+    await store.updateStatus('task-1', 'completed')
+
+    await t.assert.rejects(() => store.updateStatus('task-1', 'working'), /terminal status/)
+  })
+
+  test('a status change does not extend the retention window', async (t: TestContext) => {
+    await store.create(record({ ttl: 60_000 }))
+    const before = await redis.ttl('mcp:task:task-1')
+
+    await store.updateStatus('task-1', 'completed')
+    const after = await redis.ttl('mcp:task:task-1')
+
+    t.assert.ok(after <= before, `ttl should not grow: ${before} -> ${after}`)
+    t.assert.ok(after > 0, 'task should still be retained')
+  })
+
+  test('treats a task past its ttl as absent', async (t: TestContext) => {
+    await store.create(record({ createdAt: new Date(Date.now() - 10_000).toISOString(), ttl: 1_000 }))
+    t.assert.strictEqual(await store.get('task-1'), null)
+  })
+
+  test('list is scoped to the authorization subject', async (t: TestContext) => {
+    await store.create(record({ taskId: 'a', authSubject: 'user-1' }))
+    await store.create(record({ taskId: 'b', authSubject: 'user-2' }))
+    await store.create(record({ taskId: 'c' }))
+
+    t.assert.deepStrictEqual((await store.list('user-1')).map(x => x.taskId), ['a'])
+    t.assert.deepStrictEqual((await store.list('user-2')).map(x => x.taskId), ['b'])
+    t.assert.deepStrictEqual((await store.list()).map(x => x.taskId), ['c'])
+  })
+
+  test('delete removes the task and its index entry', async (t: TestContext) => {
+    await store.create(record())
+    await store.delete('task-1')
+
+    t.assert.strictEqual(await store.get('task-1'), null)
+    t.assert.strictEqual(await redis.zcard('mcp:tasks'), 0)
+  })
+
+  test('cleanup prunes index entries whose task key is gone', async (t: TestContext) => {
+    await store.create(record())
+    await redis.del('mcp:task:task-1')
+    t.assert.strictEqual(await redis.zcard('mcp:tasks'), 1)
+
+    await store.cleanup()
+    t.assert.strictEqual(await redis.zcard('mcp:tasks'), 0)
+  })
+
+  test('tasks created on one store instance are visible from another', async (t: TestContext) => {
+    await store.create(record({ authSubject: 'user-1' }))
+
+    // A second instance stands in for a second server in the cluster
+    const other = new RedisTaskStore({ redis })
+    const task = await other.get('task-1')
+
+    t.assert.strictEqual(task?.taskId, 'task-1')
+    t.assert.deepStrictEqual((await other.list('user-1')).map(x => x.taskId), ['task-1'])
+  })
+})

--- a/test/redis-task-store.test.ts
+++ b/test/redis-task-store.test.ts
@@ -67,6 +67,33 @@ describe('RedisTaskStore', () => {
     await t.assert.rejects(() => store.updateStatus('task-1', 'working'), /terminal status/)
   })
 
+  test('a cancelled task cannot be overwritten by a concurrent completion', async (t: TestContext) => {
+    await store.create(record())
+
+    // Both start from `working`; the Lua guard must let only one win and reject
+    // the other, so the task never leaves the terminal status it first reached.
+    const results = await Promise.allSettled([
+      store.updateStatus('task-1', 'cancelled'),
+      store.updateStatus('task-1', 'completed')
+    ])
+
+    const fulfilled = results.filter(r => r.status === 'fulfilled')
+    const rejected = results.filter(r => r.status === 'rejected')
+    t.assert.strictEqual(fulfilled.length, 1, 'exactly one write should win')
+    t.assert.strictEqual(rejected.length, 1, 'the loser must be rejected, not clobber the winner')
+
+    const final = await store.get('task-1')
+    t.assert.strictEqual(final?.status, (fulfilled[0] as PromiseFulfilledResult<any>).value.status)
+  })
+
+  test('a terminal task rejects any further transition', async (t: TestContext) => {
+    await store.create(record())
+    await store.updateStatus('task-1', 'cancelled')
+
+    await t.assert.rejects(() => store.updateStatus('task-1', 'completed'), /terminal status/)
+    t.assert.strictEqual((await store.get('task-1'))?.status, 'cancelled')
+  })
+
   test('a status change does not extend the retention window', async (t: TestContext) => {
     await store.create(record({ ttl: 60_000 }))
     const before = await redis.ttl('mcp:task:task-1')

--- a/test/resource-templates.test.ts
+++ b/test/resource-templates.test.ts
@@ -4,7 +4,7 @@ import Fastify from 'fastify'
 import mcpPlugin from '../src/index.ts'
 import type {
   JSONRPCRequest,
-  JSONRPCResponse,
+  JSONRPCResultResponse,
   ListResourcesResult,
   ListResourceTemplatesResult,
   ReadResourceResult
@@ -33,7 +33,7 @@ describe('Resource Templates', () => {
     })
 
     t.assert.strictEqual(response.statusCode, 200)
-    const body = response.json() as JSONRPCResponse
+    const body = response.json() as JSONRPCResultResponse
     const result = body.result as ListResourcesResult
     t.assert.strictEqual(result.resources.length, 1)
     t.assert.strictEqual(result.resources[0].name, 'concrete')
@@ -62,7 +62,7 @@ describe('Resource Templates', () => {
     })
 
     t.assert.strictEqual(response.statusCode, 200)
-    const body = response.json() as JSONRPCResponse
+    const body = response.json() as JSONRPCResultResponse
     const result = body.result as ListResourceTemplatesResult
     t.assert.strictEqual(result.resourceTemplates.length, 2)
 
@@ -99,7 +99,7 @@ describe('Resource Templates', () => {
     })
 
     t.assert.strictEqual(response.statusCode, 200)
-    const body = response.json() as JSONRPCResponse
+    const body = response.json() as JSONRPCResultResponse
     const result = body.result as ListResourceTemplatesResult
     t.assert.strictEqual(result.resourceTemplates.length, 0)
   })
@@ -130,7 +130,7 @@ describe('Resource Templates', () => {
     })
 
     t.assert.strictEqual(response.statusCode, 200)
-    const body = response.json() as JSONRPCResponse
+    const body = response.json() as JSONRPCResultResponse
     const result = body.result as ReadResourceResult
     t.assert.strictEqual(result.contents.length, 1)
     t.assert.ok('text' in result.contents[0] && result.contents[0].text.includes('moltnet://diary/{id}'))
@@ -161,8 +161,8 @@ describe('Resource Templates', () => {
       })
     ])
 
-    const list = (listRes.json() as JSONRPCResponse).result as ListResourcesResult
-    const templates = (templatesRes.json() as JSONRPCResponse).result as ListResourceTemplatesResult
+    const list = (listRes.json() as JSONRPCResultResponse).result as ListResourcesResult
+    const templates = (templatesRes.json() as JSONRPCResultResponse).result as ListResourceTemplatesResult
 
     t.assert.strictEqual(list.resources.length, 2)
     t.assert.strictEqual(templates.resourceTemplates.length, 2)

--- a/test/revision-behavior.test.ts
+++ b/test/revision-behavior.test.ts
@@ -1,0 +1,212 @@
+import { test, describe } from 'node:test'
+import type { TestContext } from 'node:test'
+import Fastify from 'fastify'
+import { Type } from '@sinclair/typebox'
+import mcpPlugin from '../src/index.ts'
+import { JSONRPC_VERSION, METHOD_NOT_FOUND } from '../src/schema.ts'
+import {
+  atLeast,
+  supportsTasks,
+  supportsIcons,
+  trimDefinitionToRevision,
+  capabilitiesForRevision
+} from '../src/protocol-version.ts'
+
+const OLD = '2025-03-26'
+const NEW = '2025-11-25'
+
+async function call (app: any, method: string, params: unknown, version?: string, sessionId?: string) {
+  const headers: Record<string, string> = {}
+  if (version) headers['mcp-protocol-version'] = version
+  if (sessionId) headers['mcp-session-id'] = sessionId
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/mcp',
+    headers,
+    payload: { jsonrpc: JSONRPC_VERSION, id: 1, method, params }
+  })
+  return response
+}
+
+async function buildApp (t: TestContext, opts: Record<string, unknown> = {}) {
+  const app = Fastify({ logger: false })
+  t.after(() => app.close())
+  await app.register(mcpPlugin, { enableTasks: true, ...opts })
+
+  app.mcpAddTool({
+    name: 'adder',
+    description: 'Adds two numbers',
+    inputSchema: Type.Object({ a: Type.Number(), b: Type.Number() }),
+    icons: [{ src: 'https://example.com/i.png', mimeType: 'image/png' }],
+    execution: { taskSupport: 'optional' }
+  } as any, async (params: any) => ({
+    content: [{ type: 'text', text: String(params.a + params.b) }]
+  }))
+
+  await app.ready()
+  return app
+}
+
+describe('revision comparison', () => {
+  test('atLeast orders revisions and treats absence as oldest', (t: TestContext) => {
+    t.assert.strictEqual(atLeast(NEW, NEW), true)
+    t.assert.strictEqual(atLeast('2026-07-28', NEW), true)
+    t.assert.strictEqual(atLeast(OLD, NEW), false)
+    t.assert.strictEqual(atLeast('2024-11-05', NEW), false)
+    t.assert.strictEqual(atLeast(undefined, NEW), false)
+  })
+
+  test('feature predicates follow the revision that introduced them', (t: TestContext) => {
+    t.assert.strictEqual(supportsTasks(NEW), true)
+    t.assert.strictEqual(supportsTasks(OLD), false)
+    t.assert.strictEqual(supportsIcons(NEW), true)
+    t.assert.strictEqual(supportsIcons(OLD), false)
+  })
+
+  test('trimDefinitionToRevision removes only what postdates the revision', (t: TestContext) => {
+    const definition = { name: 't', icons: [{ src: 'x' }], execution: { taskSupport: 'optional' } }
+
+    t.assert.deepStrictEqual(trimDefinitionToRevision(definition, NEW), definition)
+    t.assert.deepStrictEqual(trimDefinitionToRevision(definition, OLD), { name: 't' })
+  })
+
+  test('trimDefinitionToRevision does not mutate its input', (t: TestContext) => {
+    const definition = { name: 't', icons: [{ src: 'x' }] }
+    trimDefinitionToRevision(definition, OLD)
+    t.assert.ok(definition.icons, 'the original definition should be untouched')
+  })
+
+  test('capabilitiesForRevision drops tasks for older revisions', (t: TestContext) => {
+    const capabilities = { tools: {}, tasks: { cancel: {} } }
+
+    t.assert.deepStrictEqual(capabilitiesForRevision(capabilities, NEW), capabilities)
+    t.assert.deepStrictEqual(capabilitiesForRevision(capabilities, OLD), { tools: {} })
+    // Nothing to strip when tasks were never advertised
+    t.assert.deepStrictEqual(capabilitiesForRevision({ tools: {} }, OLD), { tools: {} })
+  })
+})
+
+describe('a client on 2025-03-26 keeps that revision\'s behavior', () => {
+  test('initialize does not advertise tasks', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    const old = await call(app, 'initialize', { protocolVersion: OLD, capabilities: {} })
+    t.assert.strictEqual(old.json().result.protocolVersion, OLD)
+    t.assert.strictEqual(old.json().result.capabilities.tasks, undefined)
+
+    const modern = await call(app, 'initialize', { protocolVersion: NEW, capabilities: {} })
+    t.assert.strictEqual(modern.json().result.protocolVersion, NEW)
+    t.assert.ok(modern.json().result.capabilities.tasks)
+  })
+
+  test('tools/list omits icons, execution and the schema dialect', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    const old = (await call(app, 'tools/list', {}, OLD)).json().result.tools[0]
+    t.assert.strictEqual(old.icons, undefined)
+    t.assert.strictEqual(old.execution, undefined)
+    t.assert.strictEqual(old.inputSchema.$schema, undefined)
+    // The fields the old revision does define are still there
+    t.assert.strictEqual(old.name, 'adder')
+    t.assert.strictEqual(old.inputSchema.type, 'object')
+
+    const modern = (await call(app, 'tools/list', {}, NEW)).json().result.tools[0]
+    t.assert.ok(modern.icons)
+    t.assert.ok(modern.execution)
+    t.assert.ok(modern.inputSchema.$schema)
+  })
+
+  test('the tasks methods do not exist', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    for (const method of ['tasks/get', 'tasks/result', 'tasks/list', 'tasks/cancel']) {
+      const body = (await call(app, method, { taskId: 'x' }, OLD)).json()
+      t.assert.strictEqual(body.error.code, METHOD_NOT_FOUND, `${method} should not exist on ${OLD}`)
+      t.assert.match(body.error.message, /not found/)
+    }
+  })
+
+  test('a task field on tools/call is ignored rather than honoured', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    const body = (await call(app, 'tools/call', {
+      name: 'adder',
+      arguments: { a: 2, b: 3 },
+      task: { ttl: 30_000 }
+    }, OLD)).json()
+
+    // Executed normally, so the caller gets the tool result and not a task handle
+    t.assert.strictEqual(body.result.content[0].text, '5')
+    t.assert.strictEqual(body.result.task, undefined)
+  })
+})
+
+describe('the session version is authoritative', () => {
+  test('a header that contradicts the negotiated version is rejected', async (t: TestContext) => {
+    const app = await buildApp(t, { enableSSE: true })
+
+    const init = await call(app, 'initialize', { protocolVersion: OLD, capabilities: {} })
+    const sessionId = init.headers['mcp-session-id'] as string
+    t.assert.strictEqual(init.json().result.protocolVersion, OLD)
+
+    const mismatched = await call(app, 'tools/list', {}, NEW, sessionId)
+    t.assert.strictEqual(mismatched.statusCode, 400)
+    t.assert.strictEqual(mismatched.json().negotiated, OLD)
+
+    const matching = await call(app, 'tools/list', {}, OLD, sessionId)
+    t.assert.strictEqual(matching.statusCode, 200)
+  })
+
+  test('a session that negotiated an old revision keeps it when the header is omitted', async (t: TestContext) => {
+    const app = await buildApp(t, { enableSSE: true })
+
+    const init = await call(app, 'initialize', { protocolVersion: OLD, capabilities: {} })
+    const sessionId = init.headers['mcp-session-id'] as string
+
+    const body = (await call(app, 'tools/list', {}, undefined, sessionId)).json()
+    t.assert.strictEqual(body.result.tools[0].icons, undefined)
+  })
+
+  test('a session that negotiated 2025-11-25 keeps it when the header is omitted', async (t: TestContext) => {
+    const app = await buildApp(t, { enableSSE: true })
+
+    const init = await call(app, 'initialize', { protocolVersion: NEW, capabilities: {} })
+    const sessionId = init.headers['mcp-session-id'] as string
+
+    // Without the session lookup this would fall back to 2025-03-26 and lose icons
+    const body = (await call(app, 'tools/list', {}, undefined, sessionId)).json()
+    t.assert.ok(body.result.tools[0].icons)
+  })
+
+  test('initialize may re-negotiate on an existing session', async (t: TestContext) => {
+    const app = await buildApp(t, { enableSSE: true })
+
+    const init = await call(app, 'initialize', { protocolVersion: OLD, capabilities: {} })
+    const sessionId = init.headers['mcp-session-id'] as string
+
+    // Re-negotiating upward must not be blocked by the earlier agreement
+    const again = await call(app, 'initialize', { protocolVersion: NEW, capabilities: {} }, NEW, sessionId)
+    t.assert.strictEqual(again.statusCode, 200)
+    t.assert.strictEqual(again.json().result.protocolVersion, NEW)
+
+    // ...and the new agreement sticks
+    const body = (await call(app, 'tools/list', {}, NEW, sessionId)).json()
+    t.assert.ok(body.result.tools[0].icons)
+  })
+
+  test('URL elicitation is refused for a session on an older revision', async (t: TestContext) => {
+    const app = await buildApp(t, { enableSSE: true })
+
+    const oldInit = await call(app, 'initialize', { protocolVersion: OLD, capabilities: {} })
+    const oldSession = oldInit.headers['mcp-session-id'] as string
+    t.assert.strictEqual(
+      await app.mcpElicitUrl(oldSession, 'Authorize', 'https://mcp.example.com/connect'),
+      null
+    )
+
+    const newInit = await call(app, 'initialize', { protocolVersion: NEW, capabilities: {} })
+    const newSession = newInit.headers['mcp-session-id'] as string
+    t.assert.ok(await app.mcpElicitUrl(newSession, 'Authorize', 'https://mcp.example.com/connect'))
+  })
+})

--- a/test/spec-2025-11-25.test.ts
+++ b/test/spec-2025-11-25.test.ts
@@ -1,0 +1,288 @@
+import { test, describe } from 'node:test'
+import type { TestContext } from 'node:test'
+import Fastify from 'fastify'
+import { Type } from '@sinclair/typebox'
+import mcpPlugin from '../src/index.ts'
+import { JSONRPC_VERSION, LATEST_PROTOCOL_VERSION, URL_ELICITATION_REQUIRED } from '../src/schema.ts'
+import { validateElicitationUrl } from '../src/security.ts'
+import { findMissingScopes, extractTokenScopes } from '../src/auth/prehandler.ts'
+import { buildDiscoveryUrls, buildClientIdMetadataDocument } from '../src/auth/oauth-client.ts'
+
+async function call (app: any, method: string, params: unknown, id = 1) {
+  const response = await app.inject({
+    method: 'POST',
+    url: '/mcp',
+    payload: { jsonrpc: JSONRPC_VERSION, id, method, params }
+  })
+  return response.json()
+}
+
+describe('protocol revision', () => {
+  test('the server speaks 2025-11-25', (t: TestContext) => {
+    t.assert.strictEqual(LATEST_PROTOCOL_VERSION, '2025-11-25')
+  })
+
+  test('URL_ELICITATION_REQUIRED is the code the spec assigns', (t: TestContext) => {
+    t.assert.strictEqual(URL_ELICITATION_REQUIRED, -32042)
+  })
+})
+
+describe('icons (SEP-973)', () => {
+  test('icons survive the round trip for tools, resources and prompts', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+
+    const icons = [{ src: 'https://example.com/icon.png', mimeType: 'image/png', sizes: ['48x48'] }]
+
+    app.mcpAddTool({
+      name: 'iconic',
+      description: 'Has an icon',
+      inputSchema: Type.Object({}),
+      icons
+    } as any)
+    app.mcpAddResource({ uriPattern: 'file://x', name: 'res', icons } as any)
+    app.mcpAddPrompt({ name: 'promptly', description: 'p', icons } as any)
+
+    await app.ready()
+
+    const tools = await call(app, 'tools/list', {})
+    t.assert.deepStrictEqual(tools.result.tools[0].icons, icons)
+
+    const resources = await call(app, 'resources/list', {})
+    t.assert.deepStrictEqual(resources.result.resources[0].icons, icons)
+
+    const prompts = await call(app, 'prompts/list', {})
+    t.assert.deepStrictEqual(prompts.result.prompts[0].icons, icons)
+  })
+})
+
+describe('JSON Schema 2020-12 dialect (SEP-1613)', () => {
+  test('published tool schemas declare the dialect', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    app.mcpAddTool({
+      name: 'x',
+      description: 'x',
+      inputSchema: Type.Object({ a: Type.String() })
+    } as any)
+    await app.ready()
+
+    const body = await call(app, 'tools/list', {})
+    t.assert.strictEqual(
+      body.result.tools[0].inputSchema.$schema,
+      'https://json-schema.org/draft/2020-12/schema'
+    )
+  })
+
+  test('an author-supplied $schema is left alone', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    app.mcpAddTool({
+      name: 'x',
+      description: 'x',
+      inputSchema: { $schema: 'http://json-schema.org/draft-07/schema#', type: 'object', properties: {} }
+    } as any)
+    await app.ready()
+
+    const body = await call(app, 'tools/list', {})
+    t.assert.strictEqual(body.result.tools[0].inputSchema.$schema, 'http://json-schema.org/draft-07/schema#')
+  })
+})
+
+describe('tool input validation is a tool error, not a protocol error (SEP-1303)', () => {
+  test('schema violations come back as isError results', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    app.mcpAddTool(
+      { name: 'strict', description: 'x', inputSchema: Type.Object({ a: Type.Number() }) } as any,
+      async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    )
+    await app.ready()
+
+    const body = await call(app, 'tools/call', { name: 'strict', arguments: { a: 'not a number' } })
+    t.assert.strictEqual(body.error, undefined)
+    t.assert.strictEqual(body.result.isError, true)
+  })
+
+  test('sanitization failures come back as isError results too', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    app.mcpAddTool(
+      { name: 'loose', description: 'x' } as any,
+      async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    )
+    await app.ready()
+
+    // Exceeds the sanitizer's string length ceiling
+    const body = await call(app, 'tools/call', { name: 'loose', arguments: { a: 'x'.repeat(20000) } })
+    t.assert.strictEqual(body.error, undefined)
+    t.assert.strictEqual(body.result.isError, true)
+  })
+})
+
+describe('URL mode elicitation (SEP-1036)', () => {
+  test('validateElicitationUrl accepts a plain https URL', (t: TestContext) => {
+    t.assert.doesNotThrow(() => validateElicitationUrl('Please sign in', 'https://mcp.example.com/connect'))
+  })
+
+  test('validateElicitationUrl rejects malformed and unsafe URLs', (t: TestContext) => {
+    t.assert.throws(() => validateElicitationUrl('m', 'not a url'), /not a valid URL/)
+    t.assert.throws(() => validateElicitationUrl('m', 'javascript:alert(1)'), /must use http or https/)
+    // Credentials in the URL would let a malicious client impersonate the user
+    t.assert.throws(() => validateElicitationUrl('m', 'https://user:pw@example.com/'), /must not embed credentials/)
+  })
+
+  test('mcpElicitUrl sends a url-mode request and returns its elicitation id', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { enableSSE: true })
+    await app.ready()
+
+    const init = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: { jsonrpc: JSONRPC_VERSION, id: 1, method: 'initialize', params: {} }
+    })
+    const sessionId = init.headers['mcp-session-id'] as string
+
+    const elicitationId = await app.mcpElicitUrl(sessionId, 'Authorize access', 'https://mcp.example.com/connect')
+    t.assert.ok(elicitationId, 'expected an elicitation id')
+
+    const notified = await app.mcpNotifyElicitationComplete(sessionId, elicitationId!)
+    t.assert.strictEqual(notified, true)
+  })
+
+  test('mcpElicitUrl refuses an unsafe URL', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { enableSSE: true })
+    await app.ready()
+
+    const init = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: { jsonrpc: JSONRPC_VERSION, id: 1, method: 'initialize', params: {} }
+    })
+    const sessionId = init.headers['mcp-session-id'] as string
+
+    t.assert.strictEqual(await app.mcpElicitUrl(sessionId, 'x', 'javascript:alert(1)'), null)
+  })
+})
+
+describe('incremental scope consent (SEP-835)', () => {
+  test('extractTokenScopes handles both token shapes', (t: TestContext) => {
+    t.assert.deepStrictEqual(extractTokenScopes({ scope: 'read write' }), ['read', 'write'])
+    t.assert.deepStrictEqual(extractTokenScopes({ scopes: ['read'] }), ['read'])
+    t.assert.deepStrictEqual(extractTokenScopes({}), [])
+    t.assert.deepStrictEqual(extractTokenScopes(null), [])
+  })
+
+  test('findMissingScopes reports only what is absent', (t: TestContext) => {
+    t.assert.deepStrictEqual(findMissingScopes(['read', 'write'], { scope: 'read' }), ['write'])
+    t.assert.deepStrictEqual(findMissingScopes(['read'], { scope: 'read write' }), [])
+    // Nothing required means nothing missing, whatever the token says
+    t.assert.deepStrictEqual(findMissingScopes(undefined, {}), [])
+    t.assert.deepStrictEqual(findMissingScopes([], {}), [])
+  })
+})
+
+describe('authorization server discovery (SEP-797)', () => {
+  test('a root issuer yields the RFC 8414 and OIDC locations', (t: TestContext) => {
+    t.assert.deepStrictEqual(buildDiscoveryUrls('https://auth.example.com'), [
+      'https://auth.example.com/.well-known/oauth-authorization-server',
+      'https://auth.example.com/.well-known/openid-configuration'
+    ])
+  })
+
+  test('a path-bearing issuer yields insertion and appending forms', (t: TestContext) => {
+    t.assert.deepStrictEqual(buildDiscoveryUrls('https://auth.example.com/tenant1'), [
+      'https://auth.example.com/.well-known/oauth-authorization-server/tenant1',
+      'https://auth.example.com/.well-known/openid-configuration/tenant1',
+      'https://auth.example.com/tenant1/.well-known/openid-configuration'
+    ])
+  })
+
+  test('a trailing slash does not change the result', (t: TestContext) => {
+    t.assert.deepStrictEqual(
+      buildDiscoveryUrls('https://auth.example.com/'),
+      buildDiscoveryUrls('https://auth.example.com')
+    )
+  })
+})
+
+describe('SSE polling support (SEP-1699)', () => {
+  test('the server closes the stream after sseMaxConnectionMs', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { enableSSE: true, sseMaxConnectionMs: 50 })
+    await app.listen({ port: 0 })
+
+    const address = app.server.address() as { port: number }
+    const response = await fetch(`http://127.0.0.1:${address.port}/mcp`, {
+      headers: { accept: 'text/event-stream' }
+    })
+
+    t.assert.strictEqual(response.status, 200)
+    t.assert.strictEqual(response.headers.get('content-type'), 'text/event-stream')
+
+    // Draining to completion proves the server ended the stream on its own
+    await response.text()
+  })
+
+  test('a stream stays open when no maximum is configured', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { enableSSE: true })
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/mcp',
+      payloadAsStream: true,
+      headers: { accept: 'text/event-stream' }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(response.headers['content-type'], 'text/event-stream')
+    response.stream().destroy()
+  })
+})
+
+describe('client ID metadata document (SEP-991)', () => {
+  test('the document identifies itself by its own URL', (t: TestContext) => {
+    const url = 'https://mcp.example.com/.well-known/oauth-client'
+    const doc = buildClientIdMetadataDocument(
+      { authorizationServer: 'https://auth.example.com', resourceUri: 'https://mcp.example.com', scopes: ['read'] },
+      url
+    )
+
+    t.assert.strictEqual(doc.client_id, url)
+    t.assert.deepStrictEqual(doc.redirect_uris, ['https://mcp.example.com/oauth/callback'])
+    t.assert.strictEqual(doc.scope, 'read')
+  })
+
+  test('the document is served and adopted as the client_id', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+
+    const { default: oauthClientPlugin } = await import('../src/auth/oauth-client.ts')
+    await app.register(oauthClientPlugin, {
+      authorizationServer: 'https://auth.example.invalid',
+      resourceUri: 'https://mcp.example.com',
+      clientIdMetadataDocument: true
+    })
+    await app.ready()
+
+    const response = await app.inject({ method: 'GET', url: '/.well-known/oauth-client' })
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(
+      response.json().client_id,
+      'https://mcp.example.com/.well-known/oauth-client'
+    )
+  })
+})

--- a/test/spec-2025-11-25.test.ts
+++ b/test/spec-2025-11-25.test.ts
@@ -12,6 +12,7 @@ async function call (app: any, method: string, params: unknown, id = 1) {
   const response = await app.inject({
     method: 'POST',
     url: '/mcp',
+    headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION },
     payload: { jsonrpc: JSONRPC_VERSION, id, method, params }
   })
   return response.json()

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -3,7 +3,7 @@ import type { TestContext } from 'node:test'
 import Fastify from 'fastify'
 import { Type } from '@sinclair/typebox'
 import mcpPlugin from '../src/index.ts'
-import { JSONRPC_VERSION, METHOD_NOT_FOUND, INVALID_PARAMS } from '../src/schema.ts'
+import { JSONRPC_VERSION, LATEST_PROTOCOL_VERSION, METHOD_NOT_FOUND, INVALID_PARAMS } from '../src/schema.ts'
 import type { Task, CreateTaskResult, ListTasksResult, CallToolResult } from '../src/schema.ts'
 import { MemoryTaskStore } from '../src/stores/memory-task-store.ts'
 import { canTransition, isTerminal, taskHasExpired, toWireTask } from '../src/stores/task-store.ts'
@@ -23,10 +23,12 @@ function record (overrides: Partial<TaskRecord> = {}): TaskRecord {
   }
 }
 
+/** Calls as a compliant 2025-11-25 client, which must echo the negotiated revision */
 async function call (app: any, method: string, params: unknown, id = 1) {
   const response = await app.inject({
     method: 'POST',
     url: '/mcp',
+    headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION },
     payload: { jsonrpc: JSONRPC_VERSION, id, method, params }
   })
   return response.json()

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -9,6 +9,7 @@ import { MemoryTaskStore } from '../src/stores/memory-task-store.ts'
 import { canTransition, isTerminal, taskHasExpired, toWireTask } from '../src/stores/task-store.ts'
 import type { TaskRecord } from '../src/stores/task-store.ts'
 import { resolveTaskAugmentation, RELATED_TASK_META_KEY } from '../src/handlers.ts'
+import { createTestAuthConfig, createTestJWT, setupMockAgent, generateMockJWKSResponse } from './auth-test-utils.ts'
 
 function record (overrides: Partial<TaskRecord> = {}): TaskRecord {
   const now = new Date().toISOString()
@@ -154,6 +155,39 @@ describe('task store', () => {
     t.assert.deepStrictEqual((await store.list('user-2')).map(x => x.taskId), ['b'])
     t.assert.deepStrictEqual((await store.list()).map(x => x.taskId), ['c'])
   })
+
+  test('concurrent cancel and completion cannot overwrite each other', async (t: TestContext) => {
+    // The core of the fix: a cancel racing a completion on the same working task
+    // must leave exactly one winner, and a task that reached a terminal status
+    // must not be moved out of it. updateStatus is atomic, so the second write
+    // observes the first and rejects rather than clobbering it.
+    const store = new MemoryTaskStore()
+    await store.create(record())
+
+    const results = await Promise.allSettled([
+      store.updateStatus('task-1', 'cancelled'),
+      store.updateStatus('task-1', 'completed')
+    ])
+
+    const fulfilled = results.filter(r => r.status === 'fulfilled')
+    const rejected = results.filter(r => r.status === 'rejected')
+    t.assert.strictEqual(fulfilled.length, 1, 'exactly one write should win')
+    t.assert.strictEqual(rejected.length, 1, 'the loser should be rejected, not silently clobber')
+
+    const final = await store.get('task-1')
+    t.assert.ok(isTerminal(final!.status))
+    // The stored status must equal the winner's — no lost update
+    t.assert.strictEqual(final!.status, (fulfilled[0] as PromiseFulfilledResult<TaskRecord>).value.status)
+  })
+
+  test('a terminal task rejects any further transition', async (t: TestContext) => {
+    const store = new MemoryTaskStore()
+    await store.create(record())
+    await store.updateStatus('task-1', 'cancelled')
+
+    await t.assert.rejects(() => store.updateStatus('task-1', 'completed'), /terminal status/)
+    t.assert.strictEqual((await store.get('task-1'))!.status, 'cancelled')
+  })
 })
 
 describe('task augmentation rules', () => {
@@ -298,17 +332,69 @@ describe('tasks over the wire', () => {
     t.assert.strictEqual(body.error.code, INVALID_PARAMS)
   })
 
-  test('tasks/list returns created tasks', async (t: TestContext) => {
+  test('tasks/list is refused without authorization', async (t: TestContext) => {
+    // Without auth every task shares the undefined subject, so listing would
+    // hand out every task's id — defeating the "random id is the capability"
+    // model. The method must not exist, matching the un-advertised capability.
     const app = await buildApp(t)
 
     await call(app, 'tools/call', { name: 'slow-add', arguments: { a: 1, b: 1 }, task: {} })
-    await call(app, 'tools/call', { name: 'slow-add', arguments: { a: 2, b: 2 }, task: {} })
 
     const body = await call(app, 'tasks/list', {})
-    const result = body.result as ListTasksResult
-    t.assert.strictEqual(result.tasks.length, 2)
-    // Storage-only fields must never reach the wire
-    t.assert.strictEqual('outcome' in result.tasks[0], false)
+    t.assert.strictEqual(body.error.code, METHOD_NOT_FOUND)
+
+    const init = await call(app, 'initialize', { protocolVersion: '2025-11-25', capabilities: {} })
+    t.assert.strictEqual(init.result.capabilities.tasks.list, undefined, 'list capability must not be advertised')
+  })
+
+  test('tasks/list is available and subject-scoped with authorization', async (t: TestContext) => {
+    const restoreMock = setupMockAgent({
+      'https://auth.example.com/.well-known/jwks.json': generateMockJWKSResponse()
+    })
+    t.after(() => restoreMock())
+
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { enableTasks: true, authorization: createTestAuthConfig() })
+    app.mcpAddTool({
+      name: 'noop',
+      description: 'x',
+      inputSchema: Type.Object({}),
+      execution: { taskSupport: 'optional' }
+    } as any, async (): Promise<CallToolResult> => ({ content: [{ type: 'text', text: 'ok' }] }))
+    await app.ready()
+
+    const authedCall = async (token: string, method: string, params: unknown) => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/mcp',
+        headers: { authorization: `Bearer ${token}`, 'mcp-protocol-version': LATEST_PROTOCOL_VERSION },
+        payload: { jsonrpc: JSONRPC_VERSION, id: 1, method, params }
+      })
+      return res.json()
+    }
+
+    const tokenA = createTestJWT({ sub: 'user-a' })
+    const tokenB = createTestJWT({ sub: 'user-b' })
+
+    // With auth, the capability is advertised
+    const init = await authedCall(tokenA, 'initialize', { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {} })
+    t.assert.deepStrictEqual(init.result.capabilities.tasks.list, {})
+
+    // Each subject creates a task
+    const a = await authedCall(tokenA, 'tools/call', { name: 'noop', arguments: {}, task: {} })
+    const b = await authedCall(tokenB, 'tools/call', { name: 'noop', arguments: {}, task: {} })
+    const taskA = (a.result as CreateTaskResult).task.taskId
+    const taskB = (b.result as CreateTaskResult).task.taskId
+
+    // A sees only its own task, never B's
+    const listA = (await authedCall(tokenA, 'tasks/list', {})).result as ListTasksResult
+    t.assert.deepStrictEqual(listA.tasks.map(x => x.taskId), [taskA])
+    t.assert.strictEqual(listA.tasks.some(x => x.taskId === taskB), false)
+
+    // A cannot reach B's task by id either
+    const cross = await authedCall(tokenA, 'tasks/get', { taskId: taskB })
+    t.assert.strictEqual(cross.error.code, INVALID_PARAMS)
   })
 
   test('task methods are unavailable when tasks are disabled', async (t: TestContext) => {

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -1,0 +1,324 @@
+import { test, describe } from 'node:test'
+import type { TestContext } from 'node:test'
+import Fastify from 'fastify'
+import { Type } from '@sinclair/typebox'
+import mcpPlugin from '../src/index.ts'
+import { JSONRPC_VERSION, METHOD_NOT_FOUND, INVALID_PARAMS } from '../src/schema.ts'
+import type { Task, CreateTaskResult, ListTasksResult, CallToolResult } from '../src/schema.ts'
+import { MemoryTaskStore } from '../src/stores/memory-task-store.ts'
+import { canTransition, isTerminal, taskHasExpired, toWireTask } from '../src/stores/task-store.ts'
+import type { TaskRecord } from '../src/stores/task-store.ts'
+import { resolveTaskAugmentation, RELATED_TASK_META_KEY } from '../src/handlers.ts'
+
+function record (overrides: Partial<TaskRecord> = {}): TaskRecord {
+  const now = new Date().toISOString()
+  return {
+    taskId: 'task-1',
+    status: 'working',
+    createdAt: now,
+    lastUpdatedAt: now,
+    ttl: 60_000,
+    method: 'tools/call',
+    ...overrides
+  }
+}
+
+async function call (app: any, method: string, params: unknown, id = 1) {
+  const response = await app.inject({
+    method: 'POST',
+    url: '/mcp',
+    payload: { jsonrpc: JSONRPC_VERSION, id, method, params }
+  })
+  return response.json()
+}
+
+/** Poll tasks/get until the task leaves the `working` state */
+async function waitForTerminal (app: any, taskId: string): Promise<Task> {
+  for (let i = 0; i < 100; i++) {
+    const body = await call(app, 'tasks/get', { taskId })
+    if (body.result && isTerminal(body.result.status)) {
+      return body.result
+    }
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error('task never reached a terminal status')
+}
+
+async function buildApp (t: TestContext, opts: Record<string, unknown> = {}) {
+  const app = Fastify({ logger: false })
+  t.after(() => app.close())
+  await app.register(mcpPlugin, { enableTasks: true, ...opts })
+
+  app.mcpAddTool({
+    name: 'slow-add',
+    description: 'Adds two numbers, slowly',
+    inputSchema: Type.Object({ a: Type.Number(), b: Type.Number() }),
+    execution: { taskSupport: 'optional' }
+  } as any, async (params: any): Promise<CallToolResult> => {
+    await new Promise(resolve => setTimeout(resolve, 20))
+    return { content: [{ type: 'text', text: String(params.a + params.b) }] }
+  })
+
+  app.mcpAddTool({
+    name: 'task-only',
+    description: 'Must be invoked as a task',
+    inputSchema: Type.Object({}),
+    execution: { taskSupport: 'required' }
+  } as any, async (): Promise<CallToolResult> => {
+    return { content: [{ type: 'text', text: 'done' }] }
+  })
+
+  app.mcpAddTool({
+    name: 'plain',
+    description: 'No task support',
+    inputSchema: Type.Object({})
+  } as any, async (): Promise<CallToolResult> => {
+    return { content: [{ type: 'text', text: 'plain' }] }
+  })
+
+  app.mcpAddTool({
+    name: 'boom',
+    description: 'Always fails',
+    inputSchema: Type.Object({}),
+    execution: { taskSupport: 'optional' }
+  } as any, async (): Promise<CallToolResult> => {
+    return { content: [{ type: 'text', text: 'nope' }], isError: true }
+  })
+
+  await app.ready()
+  return app
+}
+
+describe('task store', () => {
+  test('rejects transitions out of a terminal status', (t: TestContext) => {
+    t.assert.strictEqual(canTransition('working', 'completed'), true)
+    t.assert.strictEqual(canTransition('working', 'input_required'), true)
+    t.assert.strictEqual(canTransition('input_required', 'working'), true)
+    t.assert.strictEqual(canTransition('completed', 'working'), false)
+    t.assert.strictEqual(canTransition('cancelled', 'completed'), false)
+  })
+
+  test('identifies terminal statuses', (t: TestContext) => {
+    t.assert.strictEqual(isTerminal('completed'), true)
+    t.assert.strictEqual(isTerminal('failed'), true)
+    t.assert.strictEqual(isTerminal('cancelled'), true)
+    t.assert.strictEqual(isTerminal('working'), false)
+    t.assert.strictEqual(isTerminal('input_required'), false)
+  })
+
+  test('expires tasks once ttl has elapsed since creation', (t: TestContext) => {
+    const created = new Date(Date.now() - 10_000).toISOString()
+    t.assert.strictEqual(taskHasExpired(record({ createdAt: created, ttl: 5_000 })), true)
+    t.assert.strictEqual(taskHasExpired(record({ createdAt: created, ttl: 60_000 })), false)
+    // A null ttl means unlimited retention
+    t.assert.strictEqual(taskHasExpired(record({ createdAt: created, ttl: null })), false)
+  })
+
+  test('toWireTask drops storage-only fields', (t: TestContext) => {
+    const wire = toWireTask(record({ authSubject: 'user-1', outcome: { jsonrpc: '2.0', id: 1, result: {} } }))
+    t.assert.strictEqual('authSubject' in wire, false)
+    t.assert.strictEqual('method' in wire, false)
+    t.assert.strictEqual('outcome' in wire, false)
+    t.assert.strictEqual(wire.taskId, 'task-1')
+  })
+
+  test('MemoryTaskStore enforces the status machine', async (t: TestContext) => {
+    const store = new MemoryTaskStore()
+    await store.create(record())
+
+    const working = await store.updateStatus('task-1', 'input_required')
+    t.assert.strictEqual(working?.status, 'input_required')
+
+    await store.updateStatus('task-1', 'completed')
+    await t.assert.rejects(
+      () => store.updateStatus('task-1', 'working'),
+      /terminal status/
+    )
+  })
+
+  test('MemoryTaskStore treats expired tasks as absent', async (t: TestContext) => {
+    const store = new MemoryTaskStore()
+    await store.create(record({ createdAt: new Date(Date.now() - 10_000).toISOString(), ttl: 1_000 }))
+    t.assert.strictEqual(await store.get('task-1'), null)
+  })
+
+  test('MemoryTaskStore isolates tasks by authorization subject', async (t: TestContext) => {
+    const store = new MemoryTaskStore()
+    await store.create(record({ taskId: 'a', authSubject: 'user-1' }))
+    await store.create(record({ taskId: 'b', authSubject: 'user-2' }))
+    await store.create(record({ taskId: 'c' }))
+
+    t.assert.deepStrictEqual((await store.list('user-1')).map(x => x.taskId), ['a'])
+    t.assert.deepStrictEqual((await store.list('user-2')).map(x => x.taskId), ['b'])
+    t.assert.deepStrictEqual((await store.list()).map(x => x.taskId), ['c'])
+  })
+})
+
+describe('task augmentation rules', () => {
+  const tool = (taskSupport?: string) => ({
+    definition: { name: 't', ...(taskSupport ? { execution: { taskSupport } } : {}) }
+  }) as any
+
+  test('forbidden by default', (t: TestContext) => {
+    t.assert.deepStrictEqual(resolveTaskAugmentation(tool(), false), { mode: 'direct' })
+    t.assert.ok('error' in resolveTaskAugmentation(tool(), true))
+  })
+
+  test('optional allows either form', (t: TestContext) => {
+    t.assert.deepStrictEqual(resolveTaskAugmentation(tool('optional'), true), { mode: 'task' })
+    t.assert.deepStrictEqual(resolveTaskAugmentation(tool('optional'), false), { mode: 'direct' })
+  })
+
+  test('required rejects a direct call', (t: TestContext) => {
+    t.assert.deepStrictEqual(resolveTaskAugmentation(tool('required'), true), { mode: 'task' })
+    t.assert.ok('error' in resolveTaskAugmentation(tool('required'), false))
+  })
+})
+
+describe('tasks over the wire', () => {
+  test('capabilities advertise tasks, without list when unauthenticated', async (t: TestContext) => {
+    const app = await buildApp(t)
+    const body = await call(app, 'initialize', { protocolVersion: '2025-11-25', capabilities: {} })
+
+    t.assert.deepStrictEqual(body.result.capabilities.tasks, {
+      cancel: {},
+      requests: { tools: { call: {} } }
+    })
+  })
+
+  test('tools/list exposes execution.taskSupport', async (t: TestContext) => {
+    const app = await buildApp(t)
+    const body = await call(app, 'tools/list', {})
+    const tools = body.result.tools as any[]
+
+    t.assert.strictEqual(tools.find(x => x.name === 'slow-add').execution.taskSupport, 'optional')
+    t.assert.strictEqual(tools.find(x => x.name === 'plain').execution, undefined)
+  })
+
+  test('a task-augmented call returns CreateTaskResult, then the real result', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    const created = await call(app, 'tools/call', {
+      name: 'slow-add',
+      arguments: { a: 2, b: 3 },
+      task: { ttl: 30_000 }
+    })
+
+    const result = created.result as CreateTaskResult
+    t.assert.ok(result.task.taskId)
+    t.assert.strictEqual(result.task.status, 'working')
+    t.assert.strictEqual(result.task.ttl, 30_000)
+    t.assert.ok(result.task.createdAt)
+    t.assert.ok(result.task.lastUpdatedAt)
+    // The tool result is deliberately absent from the creation response
+    t.assert.strictEqual('content' in result, false)
+
+    const finished = await waitForTerminal(app, result.task.taskId)
+    t.assert.strictEqual(finished.status, 'completed')
+
+    const body = await call(app, 'tasks/result', { taskId: result.task.taskId })
+    t.assert.strictEqual(body.result.content[0].text, '5')
+    t.assert.deepStrictEqual(body.result._meta[RELATED_TASK_META_KEY], { taskId: result.task.taskId })
+  })
+
+  test('tasks/result blocks until the task is terminal', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    const created = await call(app, 'tools/call', {
+      name: 'slow-add',
+      arguments: { a: 1, b: 1 },
+      task: {}
+    })
+    const taskId = (created.result as CreateTaskResult).task.taskId
+
+    // Asked for immediately, while the tool is still sleeping
+    const body = await call(app, 'tasks/result', { taskId })
+    t.assert.strictEqual(body.result.content[0].text, '2')
+  })
+
+  test('a tool returning isError makes the task fail', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    const created = await call(app, 'tools/call', { name: 'boom', arguments: {}, task: {} })
+    const taskId = (created.result as CreateTaskResult).task.taskId
+
+    const finished = await waitForTerminal(app, taskId)
+    t.assert.strictEqual(finished.status, 'failed')
+    t.assert.ok(finished.statusMessage)
+
+    // tasks/result still returns exactly what the call would have returned
+    const body = await call(app, 'tasks/result', { taskId })
+    t.assert.strictEqual(body.result.isError, true)
+  })
+
+  test('a tool with taskSupport required refuses a direct call', async (t: TestContext) => {
+    const app = await buildApp(t)
+    const body = await call(app, 'tools/call', { name: 'task-only', arguments: {} })
+
+    t.assert.strictEqual(body.error.code, METHOD_NOT_FOUND)
+    t.assert.match(body.error.message, /requires task-augmented execution/)
+  })
+
+  test('a tool without task support refuses a task-augmented call', async (t: TestContext) => {
+    const app = await buildApp(t)
+    const body = await call(app, 'tools/call', { name: 'plain', arguments: {}, task: {} })
+
+    t.assert.strictEqual(body.error.code, METHOD_NOT_FOUND)
+    t.assert.match(body.error.message, /does not support task-augmented execution/)
+  })
+
+  test('tasks/cancel moves a task to cancelled and then refuses', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    const created = await call(app, 'tools/call', { name: 'slow-add', arguments: { a: 1, b: 2 }, task: {} })
+    const taskId = (created.result as CreateTaskResult).task.taskId
+
+    const cancelled = await call(app, 'tasks/cancel', { taskId })
+    t.assert.strictEqual(cancelled.result.status, 'cancelled')
+
+    const again = await call(app, 'tasks/cancel', { taskId })
+    t.assert.strictEqual(again.error.code, INVALID_PARAMS)
+    t.assert.match(again.error.message, /terminal status/)
+  })
+
+  test('unknown task ids are invalid params, not internal errors', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    for (const method of ['tasks/get', 'tasks/result', 'tasks/cancel']) {
+      const body = await call(app, method, { taskId: 'does-not-exist' })
+      t.assert.strictEqual(body.error.code, INVALID_PARAMS, `${method} should return INVALID_PARAMS`)
+    }
+  })
+
+  test('a missing taskId is rejected', async (t: TestContext) => {
+    const app = await buildApp(t)
+    const body = await call(app, 'tasks/get', {})
+    t.assert.strictEqual(body.error.code, INVALID_PARAMS)
+  })
+
+  test('tasks/list returns created tasks', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    await call(app, 'tools/call', { name: 'slow-add', arguments: { a: 1, b: 1 }, task: {} })
+    await call(app, 'tools/call', { name: 'slow-add', arguments: { a: 2, b: 2 }, task: {} })
+
+    const body = await call(app, 'tasks/list', {})
+    const result = body.result as ListTasksResult
+    t.assert.strictEqual(result.tasks.length, 2)
+    // Storage-only fields must never reach the wire
+    t.assert.strictEqual('outcome' in result.tasks[0], false)
+  })
+
+  test('task methods are unavailable when tasks are disabled', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin)
+    await app.ready()
+
+    const body = await call(app, 'tasks/get', { taskId: 'x' })
+    t.assert.strictEqual(body.error.code, METHOD_NOT_FOUND)
+
+    const init = await call(app, 'initialize', { protocolVersion: '2025-11-25', capabilities: {} })
+    t.assert.strictEqual(init.result.capabilities.tasks, undefined)
+  })
+})

--- a/test/tasks.test.ts
+++ b/test/tasks.test.ts
@@ -397,6 +397,50 @@ describe('tasks over the wire', () => {
     t.assert.strictEqual(cross.error.code, INVALID_PARAMS)
   })
 
+  test('a token without sub cannot list or reach subject-less tasks', async (t: TestContext) => {
+    const restoreMock = setupMockAgent({
+      'https://auth.example.com/.well-known/jwks.json': generateMockJWKSResponse()
+    })
+    t.after(() => restoreMock())
+
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { enableTasks: true, authorization: createTestAuthConfig() })
+    app.mcpAddTool({
+      name: 'noop',
+      description: 'x',
+      inputSchema: Type.Object({}),
+      execution: { taskSupport: 'optional' }
+    } as any, async (): Promise<CallToolResult> => ({ content: [{ type: 'text', text: 'ok' }] }))
+    await app.ready()
+
+    const authedCall = async (token: string, method: string, params: unknown) => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/mcp',
+        headers: { authorization: `Bearer ${token}`, 'mcp-protocol-version': LATEST_PROTOCOL_VERSION },
+        payload: { jsonrpc: JSONRPC_VERSION, id: 1, method, params }
+      })
+      return res.json()
+    }
+
+    // Two distinct callers, both presenting tokens that carry no `sub` claim.
+    const anonA = createTestJWT({ sub: undefined })
+    const anonB = createTestJWT({ sub: undefined })
+
+    const created = await authedCall(anonA, 'tools/call', { name: 'noop', arguments: {}, task: {} })
+    const taskId = (created.result as CreateTaskResult).task.taskId
+    t.assert.ok(taskId)
+
+    // B must not enumerate A's task via list (both resolve to an undefined subject)
+    const list = await authedCall(anonB, 'tasks/list', {})
+    t.assert.deepStrictEqual((list.result as ListTasksResult).tasks, [])
+
+    // ...nor reach it by id
+    const get = await authedCall(anonB, 'tasks/get', { taskId })
+    t.assert.strictEqual(get.error.code, INVALID_PARAMS)
+  })
+
   test('task methods are unavailable when tasks are disabled', async (t: TestContext) => {
     const app = Fastify({ logger: false })
     t.after(() => app.close())

--- a/test/tool-context-access.test.ts
+++ b/test/tool-context-access.test.ts
@@ -4,7 +4,7 @@ import Fastify from 'fastify'
 import mcpPlugin from '../src/index.ts'
 import type {
   JSONRPCRequest,
-  JSONRPCResponse,
+  JSONRPCResultResponse,
   CallToolResult,
   ReadResourceResult,
   GetPromptResult
@@ -62,7 +62,7 @@ describe('Tool Context Access', () => {
       })
 
       t.assert.strictEqual(response.statusCode, 200)
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as CallToolResult
 
       // The test should pass when we have access to request object
@@ -280,7 +280,7 @@ describe('Tool Context Access', () => {
       })
 
       t.assert.strictEqual(response.statusCode, 200)
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as CallToolResult
       const textContent = result.content[0] as { type: 'text', text: string }
       t.assert.strictEqual(textContent.text, 'Echo: Hello World', 'Traditional handler should still work')
@@ -330,7 +330,7 @@ describe('Tool Context Access', () => {
       })
 
       t.assert.strictEqual(response.statusCode, 200)
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as CallToolResult
       const textContent = result.content[0] as { type: 'text', text: string }
       t.assert.ok(textContent.text.includes('test-session-123'), 'SessionId should still be accessible')
@@ -486,7 +486,7 @@ describe('Tool Context Access', () => {
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.strictEqual(response.headers['x-resource-processed'], 'true')
 
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as ReadResourceResult
 
       // Verify context was passed correctly
@@ -542,7 +542,7 @@ describe('Tool Context Access', () => {
 
       t.assert.strictEqual(response.statusCode, 200)
 
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as ReadResourceResult
       const firstContent = result.contents[0]
       t.assert.strictEqual('text' in firstContent ? firstContent.text : '', 'Legacy resource content')
@@ -612,7 +612,7 @@ describe('Tool Context Access', () => {
       t.assert.strictEqual(response.statusCode, 200)
       t.assert.strictEqual(response.headers['x-prompt-processed'], 'true')
 
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as GetPromptResult
 
       // Verify context was passed correctly
@@ -679,7 +679,7 @@ describe('Tool Context Access', () => {
 
       t.assert.strictEqual(response.statusCode, 200)
 
-      const body = response.json() as JSONRPCResponse
+      const body = response.json() as JSONRPCResultResponse
       const result = body.result as GetPromptResult
       t.assert.strictEqual(result.messages[0].content.type, 'text')
       if (result.messages[0].content.type === 'text') {

--- a/test/typebox-validation.test.ts
+++ b/test/typebox-validation.test.ts
@@ -4,7 +4,7 @@ import Fastify from 'fastify'
 import { Type } from '@sinclair/typebox'
 import mcpPlugin from '../src/index.ts'
 import { JSONRPC_VERSION, INVALID_PARAMS } from '../src/schema.ts'
-import type { JSONRPCRequest, JSONRPCResponse, JSONRPCError, CallToolResult, GetPromptResult, ReadResourceResult } from '../src/schema.ts'
+import type { JSONRPCRequest, JSONRPCResultResponse, JSONRPCError, CallToolResult, GetPromptResult, ReadResourceResult } from '../src/schema.ts'
 
 describe('TypeBox Validation', () => {
   describe('Tool Validation', () => {
@@ -56,7 +56,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(validResponse.statusCode, 200)
-      const validBody = validResponse.json() as JSONRPCResponse
+      const validBody = validResponse.json() as JSONRPCResultResponse
       assert.strictEqual(validBody.jsonrpc, JSONRPC_VERSION)
       assert.strictEqual(validBody.id, 1)
       const validResult = validBody.result as CallToolResult
@@ -105,7 +105,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(invalidResponse.statusCode, 200)
-      const invalidBody = invalidResponse.json() as JSONRPCResponse
+      const invalidBody = invalidResponse.json() as JSONRPCResultResponse
       assert.strictEqual(invalidBody.jsonrpc, JSONRPC_VERSION)
       assert.strictEqual(invalidBody.id, 1)
       const invalidResult = invalidBody.result as CallToolResult
@@ -154,7 +154,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(wrongTypeResponse.statusCode, 200)
-      const wrongTypeBody = wrongTypeResponse.json() as JSONRPCResponse
+      const wrongTypeBody = wrongTypeResponse.json() as JSONRPCResultResponse
       const wrongTypeResult = wrongTypeBody.result as CallToolResult
       assert.strictEqual(wrongTypeResult.isError, true)
       assert.ok((wrongTypeResult.content[0] as any).text.includes('Invalid tool arguments'))
@@ -211,7 +211,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(complexResponse.statusCode, 200)
-      const complexBody = complexResponse.json() as JSONRPCResponse
+      const complexBody = complexResponse.json() as JSONRPCResultResponse
       const complexResult = complexBody.result as CallToolResult
       assert.ok((complexResult.content[0] as any).text.includes('User: Alice, Age: 30'))
     })
@@ -250,7 +250,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(unsafeResponse.statusCode, 200)
-      const unsafeBody = unsafeResponse.json() as JSONRPCResponse
+      const unsafeBody = unsafeResponse.json() as JSONRPCResultResponse
       const unsafeResult = unsafeBody.result as CallToolResult
       assert.ok((unsafeResult.content[0] as any).text.includes('Unsafe tool called'))
     })
@@ -291,7 +291,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(listResponse.statusCode, 200)
-      const listBody = listResponse.json() as JSONRPCResponse
+      const listBody = listResponse.json() as JSONRPCResultResponse
       const listResult = listBody.result as any
       assert.ok(Array.isArray(listResult.tools))
 
@@ -346,7 +346,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(validResponse.statusCode, 200)
-      const validBody = validResponse.json() as JSONRPCResponse
+      const validBody = validResponse.json() as JSONRPCResultResponse
       const validResult = validBody.result as ReadResourceResult
       assert.ok((validResult.contents[0] as any).text.includes('File content'))
     })
@@ -419,7 +419,7 @@ describe('TypeBox Validation', () => {
 
       // Should work since file://test.txt matches the pattern
       assert.strictEqual(invalidResponse.statusCode, 200)
-      const invalidBody = invalidResponse.json() as JSONRPCResponse
+      const invalidBody = invalidResponse.json() as JSONRPCResultResponse
       const invalidResult = invalidBody.result as ReadResourceResult
       assert.ok((invalidResult.contents[0] as any).text.includes('File content'))
     })
@@ -481,7 +481,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(validResponse.statusCode, 200)
-      const validBody = validResponse.json() as JSONRPCResponse
+      const validBody = validResponse.json() as JSONRPCResultResponse
       const validResult = validBody.result as GetPromptResult
       assert.ok((validResult.messages[0].content as any).text.includes('Review typescript code'))
     })
@@ -541,7 +541,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(invalidResponse.statusCode, 200)
-      const invalidBody = invalidResponse.json() as JSONRPCResponse
+      const invalidBody = invalidResponse.json() as JSONRPCResultResponse
       const invalidResult = invalidBody.result as GetPromptResult
       assert.ok((invalidResult.messages[0].content as any).text.includes('Invalid prompt arguments'))
     })
@@ -622,7 +622,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(listResponse.statusCode, 200)
-      const listBody = listResponse.json() as JSONRPCResponse
+      const listBody = listResponse.json() as JSONRPCResultResponse
       const listResult = listBody.result as any
 
       const reviewPrompt = listResult.prompts.find((prompt: any) => prompt.name === 'code-review')
@@ -681,7 +681,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(unsafeResponse.statusCode, 200)
-      const unsafeBody = unsafeResponse.json() as JSONRPCResponse
+      const unsafeBody = unsafeResponse.json() as JSONRPCResultResponse
       const unsafeResult = unsafeBody.result as GetPromptResult
       assert.ok((unsafeResult.messages[0].content as any).text.includes('Unsafe prompt called'))
     })
@@ -760,7 +760,7 @@ describe('TypeBox Validation', () => {
       })
 
       assert.strictEqual(wrongResponse.statusCode, 200)
-      const wrongBody = wrongResponse.json() as JSONRPCResponse
+      const wrongBody = wrongResponse.json() as JSONRPCResultResponse
       const wrongResult = wrongBody.result as CallToolResult
       assert.strictEqual(wrongResult.isError, true)
       assert.ok((wrongResult.content[0] as any).text.includes('Invalid tool arguments'))


### PR DESCRIPTION
Upgrades the server from `2025-06-18` to **`2025-11-25`**, the current stable MCP revision, negotiating down to `2025-06-18`, `2025-03-26` and `2024-11-05` for older clients.

`2026-07-28` is deliberately out of scope — it publishes on July 28 and is a stateless-core rewrite that removes `initialize` and `Mcp-Session-Id`, deleting the session/sticky-routing machinery this plugin is built around. That's a v3 conversation once the SDKs move. The version negotiation added here is what will let both revisions be served side by side.

## Pre-existing `2025-06-18` gaps

Found while surveying, fixed first:

- `initialize` ignored the client's requested `protocolVersion` and unconditionally echoed the latest. It now negotiates and stores the agreed revision on the session.
- No `MCP-Protocol-Version` header validation. Now `400` on an unsupported value; an absent header implies `2025-03-26`, which predates the header.
- No `Origin` check anywhere — DNS-rebinding exposure. Now validated against a new `allowedOrigins` option, answering `403` as the `2025-11-25` revision clarified.

## `2025-11-25` features

| SEP | Feature |
|---|---|
| — | Schema regenerated from upstream |
| 973 | Icons on tools, resources, resource templates, prompts |
| 1036 | URL mode elicitation + completion notifications |
| 1686 | Tasks (experimental) |
| 797 | Full RFC 8414 / OIDC discovery chain |
| 835 | Incremental scope consent |
| 991 | OAuth Client ID Metadata Documents |
| 1699 | Server-initiated SSE closure |
| 1303 | Input validation as tool errors |
| 1613 | JSON Schema 2020-12 dialect |

### Tasks

Behind an `enableTasks` option, off by default. Tools opt in individually via `execution.taskSupport`. Implements `tasks/get`, `tasks/result` (blocks until terminal), `tasks/list`, `tasks/cancel` and `notifications/tasks/status`, with memory and Redis stores mirroring the existing session-store split — so any instance can serve a poll for a task created on another.

**Security**: tasks are bound to the token subject when authorization is enabled, and cross-context access is refused. `tasks/list` is only advertised in that case, since without authorization no requestor can be identified.

## Three decisions worth reviewing

1. **`JSONRPCResponse` is now a union** of result and error variants, per upstream. `JSONRPCError` is re-exported as a deprecated alias for the renamed `JSONRPCErrorResponse` so consumers keep compiling; internal code and tests moved to `JSONRPCResultResponse`.
2. **Event IDs were *not* re-encoded to carry stream identity**, despite SEP-1699 suggesting it. `RedisSessionStore` uses them as Redis Stream IDs (`xrange` on `(<eventId>-0`), so they must stay numeric. Streams are session-scoped and a resuming client sends `Mcp-Session-Id` alongside `Last-Event-ID`, which disambiguates.
3. **`SessionStore` gained a required `update()` method.** `create()` resets a session's message history, so it could not double as an upsert. This breaks any external `SessionStore` implementation.

SEP-985 needed no change: as a resource server we already emit `resource_metadata` in the challenge *and* serve `/.well-known/oauth-protected-resource`, which is exactly the fallback it makes clients honour.

## Breaking changes (2.0.0)

- `LATEST_PROTOCOL_VERSION` is `2025-11-25`
- `JSONRPCResponse` is a union — use `JSONRPCResultResponse` to read `.result`
- `EnumSchema` drops `enumNames` for the standards-based `oneOf`/`anyOf` form
- Tool sanitization failures return `isError: true` results, not `INVALID_PARAMS`
- Published tool schemas carry an explicit `$schema`
- `SessionStore` implementations must add `update()`

## Testing

`npm run ci` green: **369 tests, 0 failures** (up from 302), lint and typecheck clean, build succeeds. New files: `test/protocol-negotiation.test.ts`, `test/tasks.test.ts`, `test/redis-task-store.test.ts`, `test/spec-2025-11-25.test.ts`. `spec/*.md` refreshed from upstream plus a new `spec/tasks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEzW3gE2367dkV2CmtJbB