### PR TITLE
feat(brokers): export message broker classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,23 @@ await app.register(mcpPlugin, {
 })
 ```
 
+### Message Broker Exports
+
+`MemoryMessageBroker`, `RedisMessageBroker`, and the `MessageBroker` interface are exported from the package's public entry point, so you can use them directly without deep-importing into `dist/brokers/...`:
+
+```typescript
+import { MessageBroker, MemoryMessageBroker, RedisMessageBroker } from '@platformatic/mcp'
+
+const broker: MessageBroker = new MemoryMessageBroker()
+// or: new RedisMessageBroker(redis)
+```
+
+- **`MessageBroker`**: the pub/sub interface the plugin uses internally to deliver messages to SSE clients — `publish(topic, message)`, `subscribe(topic, handler)`, `unsubscribe(topic)`, and `close()`.
+- **`MemoryMessageBroker`**: in-process implementation backed by [MQEmitter](https://github.com/mcollina/mqemitter). Used automatically when no `redis` option is passed; messages only reach clients connected to the same server instance.
+- **`RedisMessageBroker`**: distributed implementation backed by [mqemitter-redis](https://github.com/mcollina/mqemitter-redis). Used automatically when the `redis` option is passed; publishes go through Redis so messages reach clients connected to *any* server instance.
+
+These are the same broker classes the plugin instantiates internally based on the `redis` option. Exporting them lets you construct one directly for custom pub/sub logic, tests, or scripts that need to publish/subscribe without spinning up the full plugin.
+
 ### Multi-Instance Deployment
 
 With Redis configuration, you can run multiple instances of your MCP server:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@platformatic/mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@platformatic/mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^11.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,6 +221,19 @@ export type {
   StdioTransportOptions
 } from './stdio.ts'
 
+// Export message broker implementations and interface
+export {
+  RedisMessageBroker
+} from './brokers/redis-message-broker.ts'
+
+export {
+  MemoryMessageBroker
+} from './brokers/memory-message-broker.ts'
+
+export type {
+  MessageBroker
+} from './brokers/message-broker.ts'
+
 // Export plugin types
 export type {
   MCPPluginOptions,

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -6,6 +6,7 @@ import {
 } from 'tsd'
 import { Type } from '@sinclair/typebox'
 import type { FastifyReply } from 'fastify'
+import { RedisMessageBroker, MemoryMessageBroker } from '../dist/index.js'
 import type {
   ToolHandler,
   ResourceHandler,
@@ -22,6 +23,7 @@ import type {
   UnsafeMCPResource,
   UnsafeMCPPrompt,
   JSONRPCMessage,
+  MessageBroker,
 } from '../dist/index.js'
 
 // ─── ToolHandler ─────────────────────────────────────────────────────
@@ -260,3 +262,26 @@ expectAssignable<SSESession>({
 // Missing required fields
 expectNotAssignable<SSESession>({ id: 'sess-1' })
 expectNotAssignable<SSESession>({ id: 'sess-1', eventId: 0 })
+
+// ─── Message brokers ────────────────────────────────────────────────
+
+// Both broker implementations are importable from the package root
+expectType<typeof RedisMessageBroker>(RedisMessageBroker)
+expectType<typeof MemoryMessageBroker>(MemoryMessageBroker)
+
+// MemoryMessageBroker satisfies the MessageBroker interface
+expectAssignable<MessageBroker>(new MemoryMessageBroker())
+
+// RedisMessageBroker's methods match the MessageBroker interface shape,
+// checked via the prototype since constructing one needs a live Redis client
+expectType<(topic: string, message: JSONRPCMessage) => Promise<void>>(
+  RedisMessageBroker.prototype.publish
+)
+expectType<(topic: string, handler: (message: JSONRPCMessage) => void) => Promise<void>>(
+  RedisMessageBroker.prototype.subscribe
+)
+expectType<(topic: string) => Promise<void>>(RedisMessageBroker.prototype.unsubscribe)
+expectType<() => Promise<void>>(RedisMessageBroker.prototype.close)
+
+// Constructor still requires a real Redis instance, not an arbitrary object
+expectError(new RedisMessageBroker({}))


### PR DESCRIPTION
 Export `RedisMessageBroker`, `MemoryMessageBroker`, and the `MessageBroker` type from the package's public entry point so consumers don't have to deep-import into `dist/brokers/....`