### PR TITLE
fix(sse): advance the memory session event-id counter

### DIFF
--- a/src/stores/memory-session-store.ts
+++ b/src/stores/memory-session-store.ts
@@ -66,6 +66,14 @@ export class MemorySessionStore implements SessionStore {
     // Update session metadata
     const session = this.sessions.get(sessionId)
     if (session) {
+      // Persist the numeric counter, not just lastEventId. get() hands callers a
+      // copy, so the `++session.eventId` a caller does on that copy is otherwise
+      // never stored — leaving every SSE event with id "1" and breaking
+      // Last-Event-ID resumption. The Redis backend already persists this.
+      const numericEventId = parseInt(eventId, 10)
+      if (!Number.isNaN(numericEventId)) {
+        session.eventId = numericEventId
+      }
       session.lastEventId = eventId
       session.lastActivity = new Date()
     }

--- a/test/memory-session-store.test.ts
+++ b/test/memory-session-store.test.ts
@@ -1,0 +1,56 @@
+import { test, describe } from 'node:test'
+import type { TestContext } from 'node:test'
+import { MemorySessionStore } from '../src/stores/memory-session-store.ts'
+import type { SessionMetadata } from '../src/stores/session-store.ts'
+
+function newSession (id: string): SessionMetadata {
+  return { id, eventId: 0, createdAt: new Date(), lastActivity: new Date() }
+}
+
+/**
+ * Reproduce what routes/mcp.ts sendSSEToStreams does for each event: read the
+ * session (a copy), bump the counter on the copy, then persist via addMessage.
+ * Before the fix the counter was never stored, so every event got id "1".
+ */
+async function emit (store: MemorySessionStore, sessionId: string, i: number): Promise<string> {
+  const session = await store.get(sessionId)
+  const eventId = (++session!.eventId).toString()
+  await store.addMessage(sessionId, eventId, { jsonrpc: '2.0', method: 'notifications/test', params: { i } })
+  return eventId
+}
+
+describe('MemorySessionStore event id counter', () => {
+  test('the numeric counter advances so SSE event ids are distinct and ascending', async (t: TestContext) => {
+    const store = new MemorySessionStore(100)
+    await store.create(newSession('s1'))
+
+    const ids = [await emit(store, 's1', 1), await emit(store, 's1', 2), await emit(store, 's1', 3)]
+
+    t.assert.deepStrictEqual(ids, ['1', '2', '3'], 'each event must get a fresh ascending id, not repeat "1"')
+    t.assert.strictEqual((await store.get('s1'))!.eventId, 3, 'the stored counter must reflect the last emitted event')
+  })
+
+  test('getMessagesFrom replays exactly the events after the given id', async (t: TestContext) => {
+    const store = new MemorySessionStore(100)
+    await store.create(newSession('s1'))
+
+    await emit(store, 's1', 1)
+    await emit(store, 's1', 2)
+    await emit(store, 's1', 3)
+
+    // Resuming after event "1" must replay 2 and 3 — impossible when every id is "1"
+    const replayed = await store.getMessagesFrom('s1', '1')
+    t.assert.deepStrictEqual(replayed.map(r => r.eventId), ['2', '3'])
+
+    const fromTwo = await store.getMessagesFrom('s1', '2')
+    t.assert.deepStrictEqual(fromTwo.map(r => r.eventId), ['3'])
+  })
+
+  test('a fresh session starts the counter at zero, first event is "1"', async (t: TestContext) => {
+    const store = new MemorySessionStore(100)
+    await store.create(newSession('s1'))
+
+    t.assert.strictEqual((await store.get('s1'))!.eventId, 0)
+    t.assert.strictEqual(await emit(store, 's1', 1), '1')
+  })
+})


### PR DESCRIPTION
Fixes #164.

## Problem

With the **memory** session backend, every SSE event was emitted with `id: 1`, breaking `Last-Event-ID` resumption. `MemorySessionStore.addMessage` persisted `lastEventId` but never the numeric `eventId` counter; `sendSSEToStreams` increments the counter on the **copy** `get()` returns, so the increment was never stored. The stored counter stayed at `0`, so the next event computed `++0 = 1` again. The Redis backend already HSETs `eventId`, so it was unaffected.

Consequence: duplicate `id:` on every event, and `getMessagesFrom(sessionId, '1')` matched the first history entry and replayed the wrong slice — resumption was effectively broken on memory.

## Fix

Persist the numeric counter in `MemorySessionStore.addMessage`, mirroring what the Redis store already does. One-line change plus a guard against a non-numeric id.

## Tests

New `test/memory-session-store.test.ts` reproduces the exact `get`-copy → bump → `addMessage` flow and asserts:
- event ids are distinct and ascending (`['1','2','3']`, not `['1','1','1']`)
- the stored counter reflects the last event
- `getMessagesFrom` replays exactly the events after a given id

These fail before the fix and pass after. Full suite green (305 tests), lint clean.

## Scope

This is **pre-existing on `main`**, independent of #162 (the 2025-11-25 spec upgrade). It touches `addMessage`, a different method than the `update()` #162 adds to the same file, so the two do not conflict. Surfaced during the adversarial review of #162 and split out here as an unrelated concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xEzW3gE2367dkV2CmtJbB