### PR TITLE
fix(redis broker): bound graceful shutdown timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,15 @@ PORT=3001 REDIS_HOST=redis.example.com node server.js
 PORT=3002 REDIS_HOST=redis.example.com node server.js
 ```
 
+### Graceful Shutdown
+
+`RedisMessageBroker.close()` is bounded: it waits up to `closeTimeoutMs` (default 2000ms) for
+mqemitter-redis to close its Redis connections gracefully, then falls back to forcibly
+disconnecting them so Fastify's `onClose` hooks - and the process shutdown deadline enforced by
+most orchestrators - are never blocked by a Redis outage or a stuck reconnect. Pass
+`closeTimeoutMs` and `onCloseTimeout` as a second argument to `RedisMessageBroker` to customize
+this behavior, e.g. to log when a shutdown had to fall back to the forced path.
+
 ### Session Persistence Features
 
 **Automatic Session Management:**

--- a/src/brokers/redis-message-broker.ts
+++ b/src/brokers/redis-message-broker.ts
@@ -3,10 +3,46 @@ import MQEmitterRedis from 'mqemitter-redis'
 import type { JSONRPCMessage } from '../schema.ts'
 import type { MessageBroker } from './message-broker.ts'
 
-export class RedisMessageBroker implements MessageBroker {
-  private emitter: any
+const DEFAULT_CLOSE_TIMEOUT_MS = 2000
 
-  constructor (redis: Redis) {
+interface RedisConnLike {
+  disconnect (): unknown
+  quit? (...args: unknown[]): Promise<unknown>
+}
+
+function suppressUnhandledQuitRejection (conn?: RedisConnLike): void {
+  if (typeof conn?.quit !== 'function') {
+    return
+  }
+  const quit = conn.quit.bind(conn)
+  conn.quit = (...args: unknown[]) => {
+    const result = quit(...args)
+    result?.catch?.(() => {})
+    return result
+  }
+}
+
+interface RedisMQEmitter extends ReturnType<typeof MQEmitterRedis> {
+  removeAllListeners? (topic: string, done?: (err?: Error) => void): void
+  subConn?: RedisConnLike
+  pubConn?: RedisConnLike
+  _close?: (cb: () => void) => void
+}
+
+export interface RedisMessageBrokerOptions {
+  /** Bound on how long close() waits for a graceful shutdown, in ms (default 2000). */
+  closeTimeoutMs?: number
+  /** Called with closeTimeoutMs when close() falls back to a forced disconnect after it elapses. */
+  onCloseTimeout?: (closeTimeoutMs: number) => void
+}
+
+export class RedisMessageBroker implements MessageBroker {
+  private readonly emitter: RedisMQEmitter
+  private readonly closeTimeoutMs: number
+  private readonly onCloseTimeout?: (closeTimeoutMs: number) => void
+  private closePromise: Promise<void> | null = null
+
+  constructor (redis: Redis, options: RedisMessageBrokerOptions = {}) {
     this.emitter = MQEmitterRedis({
       port: redis.options.port,
       host: redis.options.host,
@@ -14,11 +50,15 @@ export class RedisMessageBroker implements MessageBroker {
       db: redis.options.db || 0,
       family: redis.options.family || 4
     })
+    this.closeTimeoutMs = options.closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS
+    this.onCloseTimeout = options.onCloseTimeout
+    suppressUnhandledQuitRejection(this.emitter.subConn)
+    suppressUnhandledQuitRejection(this.emitter.pubConn)
   }
 
   async publish (topic: string, message: JSONRPCMessage): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.emitter.emit({ topic, message }, (err: any) => {
+      this.emitter.emit({ topic, message }, (err) => {
         if (err) {
           reject(err)
         } else {
@@ -30,8 +70,8 @@ export class RedisMessageBroker implements MessageBroker {
 
   async subscribe (topic: string, handler: (message: JSONRPCMessage) => void): Promise<void> {
     return new Promise((resolve) => {
-      this.emitter.on(topic, (msg: any, cb: any) => {
-        handler(msg.message)
+      this.emitter.on(topic, (packet, cb) => {
+        handler(packet.message)
         cb()
       })
       resolve()
@@ -40,16 +80,60 @@ export class RedisMessageBroker implements MessageBroker {
 
   async unsubscribe (topic: string): Promise<void> {
     return new Promise((resolve) => {
-      this.emitter.removeAllListeners(topic)
+      this.emitter.removeAllListeners?.(topic)
       resolve()
     })
   }
 
   async close (): Promise<void> {
+    if (!this.closePromise) {
+      this.closePromise = this.closeWithTimeout()
+    }
+    return this.closePromise
+  }
+
+  private closeWithTimeout (): Promise<void> {
     return new Promise((resolve) => {
+      let timedOut = false
+
+      const timer = setTimeout(() => {
+        timedOut = true
+        this.forceClose()
+        resolve()
+      }, this.closeTimeoutMs)
+
       this.emitter.close(() => {
+        if (timedOut) {
+          return
+        }
+        clearTimeout(timer)
         resolve()
       })
     })
+  }
+
+  // Best-effort: none of these steps may throw or hang, since this runs
+  // after the graceful close already failed to complete in time.
+  private forceClose (): void {
+    try {
+      this.emitter.subConn?.disconnect()
+    } catch {
+      // connection may already be in a broken state
+    }
+    try {
+      this.emitter.pubConn?.disconnect()
+    } catch {
+      // connection may already be in a broken state
+    }
+    try {
+      this.emitter._close?.(() => {})
+    } catch {
+      // finalizer is best-effort
+    }
+    try {
+      this.onCloseTimeout?.(this.closeTimeoutMs)
+    } catch {
+      // caller-supplied hook must not break shutdown
+    }
   }
 }

--- a/src/brokers/redis-message-broker.ts
+++ b/src/brokers/redis-message-broker.ts
@@ -42,6 +42,11 @@ export class RedisMessageBroker implements MessageBroker {
   private readonly onCloseTimeout?: (closeTimeoutMs: number) => void
   private closePromise: Promise<void> | null = null
 
+  /**
+   * @param redis Redis connection whose options are reused for the MQEmitter pub/sub connections.
+   * @param options.closeTimeoutMs Bound on how long close() waits for a graceful shutdown, in ms (default 2000).
+   * @param options.onCloseTimeout Called with closeTimeoutMs when close() falls back to a forced disconnect after it elapses.
+   */
   constructor (redis: Redis, options: RedisMessageBrokerOptions = {}) {
     this.emitter = MQEmitterRedis({
       port: redis.options.port,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { TokenValidator } from './auth/token-validator.ts'
 import { createAuthPreHandler } from './auth/prehandler.ts'
 import oauthClientPlugin from './auth/oauth-client.ts'
 import authRoutesPlugin from './routes/auth-routes.ts'
+import { quitWithTimeout } from './redis-quit-with-timeout.ts'
 
 // Import and export MCP protocol types
 import type {
@@ -46,6 +47,8 @@ import type {
   ElicitRequestFormParams,
   ElicitRequestURLParams
 } from './schema.ts'
+
+const REDIS_QUIT_TIMEOUT_MS = 2000
 
 const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOptions) {
   const serverInfo: Implementation = opts.serverInfo ?? {
@@ -77,7 +80,11 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
     // Redis implementations for horizontal scaling
     redis = new Redis(opts.redis)
     sessionStore = new RedisSessionStore({ redis, maxMessages: 100 })
-    messageBroker = new RedisMessageBroker(redis)
+    messageBroker = new RedisMessageBroker(redis, {
+      onCloseTimeout: (closeTimeoutMs) => {
+        app.log.warn({ closeTimeoutMs }, 'Redis message broker close timed out; forcing disconnect')
+      }
+    })
     if (enableTasks) {
       taskStore = new RedisTaskStore({ redis, defaultTtlMs: opts.taskDefaultTtlMs })
     }
@@ -192,10 +199,15 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
     // Execute all unsubscribes in parallel
     await Promise.all(unsubscribePromises)
 
-    if (redis) {
-      await redis.quit()
+    try {
+      await messageBroker.close()
+    } finally {
+      if (redis) {
+        await quitWithTimeout(redis, REDIS_QUIT_TIMEOUT_MS, () => {
+          app.log.warn({ timeoutMs: REDIS_QUIT_TIMEOUT_MS }, 'Redis client quit timed out; forcing disconnect')
+        })
+      }
     }
-    await messageBroker.close()
 
     // Clean up token validator
     if (tokenValidator) {

--- a/src/redis-quit-with-timeout.ts
+++ b/src/redis-quit-with-timeout.ts
@@ -2,50 +2,39 @@ import type { Redis } from 'ioredis'
 
 // Mirrors RedisMessageBroker's own bounded close: races a graceful quit()
 // against a timer, falling back to a forced disconnect so a Redis outage
-// can't block onClose. Never rejects, and the timer stays refed since it's
-// the only thing driving resolution once quit() hangs. Also force-disconnects
-// on a rejected quit() (e.g. the connection dropped mid-command), since
-// ioredis can otherwise be left reconnecting with an active socket/timer.
+// can't block onClose. Never rejects: quit()'s rejection is mapped to an
+// outcome before the race (a rejected loser would otherwise reject the race
+// later), and it also force-disconnects on that path (e.g. the connection
+// dropped mid-command), since ioredis can otherwise be left reconnecting
+// with an active socket/timer. The timer is cleared in finally so a fast
+// quit() doesn't keep the event loop alive for the full timeout.
 export async function quitWithTimeout (client: Redis, timeoutMs: number, onTimeout: () => void): Promise<void> {
-  await new Promise<void>((resolve) => {
-    let timedOut = false
+  let timer: NodeJS.Timeout | undefined
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), timeoutMs)
+  })
 
-    // Both fallback paths are best-effort: a throwing onTimeout() or
-    // disconnect() must neither crash the process (this runs in a timer
-    // callback) nor leave this promise pending, so each step is isolated
-    // and resolution is guaranteed by the finally.
-    const forceDisconnect = (notifyTimeout: boolean): void => {
+  try {
+    const outcome = await Promise.race([
+      client.quit().then(() => 'ok' as const, () => 'error' as const),
+      timeout
+    ])
+    if (outcome === 'ok') {
+      return
+    }
+    if (outcome === 'timeout') {
       try {
-        if (notifyTimeout) {
-          try {
-            onTimeout()
-          } catch {
-            // caller-supplied hook must not break shutdown
-          }
-        }
-        try {
-          client.disconnect()
-        } catch {
-          // connection may already be in a broken state
-        }
-      } finally {
-        resolve()
+        onTimeout()
+      } catch {
+        // caller-supplied hook must not break shutdown
       }
     }
-
-    const timer = setTimeout(() => {
-      timedOut = true
-      forceDisconnect(true)
-    }, timeoutMs)
-
-    client.quit().then(() => {
-      if (timedOut) return
-      clearTimeout(timer)
-      resolve()
-    }).catch(() => {
-      if (timedOut) return
-      clearTimeout(timer)
-      forceDisconnect(false)
-    })
-  })
+    try {
+      client.disconnect()
+    } catch {
+      // connection may already be in a broken state
+    }
+  } finally {
+    clearTimeout(timer)
+  }
 }

--- a/src/redis-quit-with-timeout.ts
+++ b/src/redis-quit-with-timeout.ts
@@ -1,0 +1,51 @@
+import type { Redis } from 'ioredis'
+
+// Mirrors RedisMessageBroker's own bounded close: races a graceful quit()
+// against a timer, falling back to a forced disconnect so a Redis outage
+// can't block onClose. Never rejects, and the timer stays refed since it's
+// the only thing driving resolution once quit() hangs. Also force-disconnects
+// on a rejected quit() (e.g. the connection dropped mid-command), since
+// ioredis can otherwise be left reconnecting with an active socket/timer.
+export async function quitWithTimeout (client: Redis, timeoutMs: number, onTimeout: () => void): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let timedOut = false
+
+    // Both fallback paths are best-effort: a throwing onTimeout() or
+    // disconnect() must neither crash the process (this runs in a timer
+    // callback) nor leave this promise pending, so each step is isolated
+    // and resolution is guaranteed by the finally.
+    const forceDisconnect = (notifyTimeout: boolean): void => {
+      try {
+        if (notifyTimeout) {
+          try {
+            onTimeout()
+          } catch {
+            // caller-supplied hook must not break shutdown
+          }
+        }
+        try {
+          client.disconnect()
+        } catch {
+          // connection may already be in a broken state
+        }
+      } finally {
+        resolve()
+      }
+    }
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      forceDisconnect(true)
+    }, timeoutMs)
+
+    client.quit().then(() => {
+      if (timedOut) return
+      clearTimeout(timer)
+      resolve()
+    }).catch(() => {
+      if (timedOut) return
+      clearTimeout(timer)
+      forceDisconnect(false)
+    })
+  })
+}

--- a/test/redis-broker-shutdown-integration.test.ts
+++ b/test/redis-broker-shutdown-integration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { createServer } from 'node:net'
+import type { AddressInfo } from 'node:net'
+import { setTimeout as sleep } from 'node:timers/promises'
+import Fastify from 'fastify'
+import mcpPlugin from '../src/index.ts'
+
+const INFO_REPLY = 'redis_version:7.0.0\r\nloading:0\r\n'
+
+function startUnresponsiveRedisServer (): Promise<{ port: number, stop: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = createServer((socket) => {
+      socket.on('data', (chunk) => {
+        if (/INFO/i.test(chunk.toString('utf8'))) {
+          socket.write(`$${Buffer.byteLength(INFO_REPLY)}\r\n${INFO_REPLY}\r\n`)
+        }
+        // Any other command (notably QUIT) is silently dropped.
+      })
+      socket.on('error', () => {})
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo
+      resolve({
+        port,
+        stop: () => new Promise<void>((resolve) => server.close(() => resolve()))
+      })
+    })
+  })
+}
+
+describe('MCP plugin shutdown (Fastify integration)', () => {
+  it('bounds app.close() when Redis cannot quit gracefully', async () => {
+    const { port, stop } = await startUnresponsiveRedisServer()
+
+    const app = Fastify()
+    await app.register(mcpPlugin, {
+      redis: { host: '127.0.0.1', port }
+    })
+    await app.ready()
+
+    // Give the plugin's Redis connections (session store client plus the
+    // broker's subConn/pubConn) time to complete the INFO ready-check
+    // against localhost before we shut down.
+    await sleep(300)
+    const STRICT_DEADLINE_MS = 5000
+
+    try {
+      const start = process.hrtime.bigint()
+      await app.close()
+      const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6
+      assert.ok(
+        elapsedMs < STRICT_DEADLINE_MS,
+        `app.close() took ${elapsedMs}ms, expected under ${STRICT_DEADLINE_MS}ms`
+      )
+    } finally {
+      await stop()
+    }
+  })
+})

--- a/test/redis-message-broker-shutdown.test.ts
+++ b/test/redis-message-broker-shutdown.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert'
+import { RedisMessageBroker, type RedisMessageBrokerOptions } from '../src/brokers/redis-message-broker.ts'
+
+function createBroker (emitter: object, options: RedisMessageBrokerOptions = {}): RedisMessageBroker {
+  return Object.assign(Object.create(RedisMessageBroker.prototype), {
+    emitter,
+    closeTimeoutMs: options.closeTimeoutMs ?? 2000,
+    onCloseTimeout: options.onCloseTimeout,
+    closePromise: null
+  }) as RedisMessageBroker
+}
+
+describe('RedisMessageBroker shutdown', () => {
+  it('resolves as soon as the emitter close callback fires', async () => {
+    const close = mock.fn((cb: () => void) => cb())
+    const broker = createBroker({ close })
+
+    await broker.close()
+
+    assert.strictEqual(close.mock.callCount(), 1)
+  })
+
+  it('falls back to a forced disconnect and finalizer when close hangs', async () => {
+    const disconnectSub = mock.fn()
+    const disconnectPub = mock.fn()
+    const finalize = mock.fn((cb: () => void) => cb())
+    const onCloseTimeout = mock.fn()
+    const close = mock.fn(() => {}) // never invokes its callback
+
+    const broker = createBroker({
+      close,
+      subConn: { disconnect: disconnectSub },
+      pubConn: { disconnect: disconnectPub },
+      _close: finalize
+    }, { closeTimeoutMs: 20, onCloseTimeout })
+
+    await broker.close()
+
+    assert.strictEqual(disconnectSub.mock.callCount(), 1)
+    assert.strictEqual(disconnectPub.mock.callCount(), 1)
+    assert.strictEqual(finalize.mock.callCount(), 1)
+    assert.strictEqual(onCloseTimeout.mock.callCount(), 1)
+  })
+
+  it('ignores a graceful close callback that fires after the timeout already resolved', async () => {
+    let lateCb: (() => void) | undefined
+    const close = mock.fn((cb: () => void) => { lateCb = cb })
+    const finalize = mock.fn((cb: () => void) => cb())
+
+    const broker = createBroker({ close, _close: finalize }, { closeTimeoutMs: 20 })
+
+    await broker.close()
+    assert.strictEqual(finalize.mock.callCount(), 1)
+
+    // Should not throw, double-resolve, or re-run forced cleanup.
+    assert.doesNotThrow(() => lateCb?.())
+    assert.strictEqual(finalize.mock.callCount(), 1)
+  })
+
+  it('tolerates forced-cleanup steps throwing and still resolves', async () => {
+    const disconnectSub = mock.fn(() => { throw new Error('sub connection already broken') })
+    const disconnectPub = mock.fn()
+    const finalize = mock.fn((cb: () => void) => cb())
+    const onCloseTimeout = mock.fn(() => { throw new Error('logging hook failed') })
+    const close = mock.fn(() => {}) // never invokes its callback
+
+    const broker = createBroker({
+      close,
+      subConn: { disconnect: disconnectSub },
+      pubConn: { disconnect: disconnectPub },
+      _close: finalize
+    }, { closeTimeoutMs: 20, onCloseTimeout })
+
+    await assert.doesNotReject(broker.close())
+
+    assert.strictEqual(disconnectSub.mock.callCount(), 1)
+    assert.strictEqual(disconnectPub.mock.callCount(), 1)
+    assert.strictEqual(finalize.mock.callCount(), 1)
+  })
+
+  it('resolves on timeout even without subConn/pubConn/_close available', async () => {
+    const close = mock.fn(() => {}) // never invokes its callback
+
+    const broker = createBroker({ close }, { closeTimeoutMs: 20 })
+
+    await assert.doesNotReject(broker.close())
+  })
+
+  it('shares a single close across concurrent and repeated calls', async () => {
+    let resolveClose: (() => void) | undefined
+    const close = mock.fn((cb: () => void) => { resolveClose = cb })
+    const broker = createBroker({ close })
+
+    const first = broker.close()
+    const second = broker.close()
+    resolveClose?.()
+    await Promise.all([first, second])
+
+    // A call after the broker has already settled must not re-invoke close().
+    await broker.close()
+
+    assert.strictEqual(close.mock.callCount(), 1)
+  })
+})

--- a/test/redis-quit-with-timeout.test.ts
+++ b/test/redis-quit-with-timeout.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert'
+import type { Redis } from 'ioredis'
+import { quitWithTimeout } from '../src/redis-quit-with-timeout.ts'
+
+function fakeClient (quit: () => Promise<unknown>): { client: Redis, disconnect: ReturnType<typeof mock.fn> } {
+  const disconnect = mock.fn()
+  const client = { quit, disconnect } as unknown as Redis
+  return { client, disconnect }
+}
+
+describe('quitWithTimeout', () => {
+  it('resolves without disconnecting when quit() succeeds', async () => {
+    const { client, disconnect } = fakeClient(() => Promise.resolve('OK'))
+    const onTimeout = mock.fn()
+
+    await quitWithTimeout(client, 50, onTimeout)
+
+    assert.strictEqual(disconnect.mock.callCount(), 0)
+    assert.strictEqual(onTimeout.mock.callCount(), 0)
+  })
+
+  it('force-disconnects when quit() rejects before the timeout', async () => {
+    const { client, disconnect } = fakeClient(() => Promise.reject(new Error('Connection is closed.')))
+    const onTimeout = mock.fn()
+
+    await quitWithTimeout(client, 200, onTimeout)
+
+    assert.strictEqual(disconnect.mock.callCount(), 1)
+    assert.strictEqual(onTimeout.mock.callCount(), 0)
+  })
+
+  it('falls back to a forced disconnect and onTimeout when quit() never settles', async () => {
+    const { client, disconnect } = fakeClient(() => new Promise(() => {}))
+    const onTimeout = mock.fn()
+
+    await quitWithTimeout(client, 20, onTimeout)
+
+    assert.strictEqual(disconnect.mock.callCount(), 1)
+    assert.strictEqual(onTimeout.mock.callCount(), 1)
+  })
+
+  it('resolves on timeout even when onTimeout and disconnect both throw', async () => {
+    const disconnect = mock.fn(() => { throw new Error('connection already broken') })
+    const client = { quit: () => new Promise(() => {}), disconnect } as unknown as Redis
+    const onTimeout = mock.fn(() => { throw new Error('logging hook failed') })
+
+    await assert.doesNotReject(quitWithTimeout(client, 20, onTimeout))
+
+    assert.strictEqual(onTimeout.mock.callCount(), 1)
+    assert.strictEqual(disconnect.mock.callCount(), 1)
+  })
+
+  it('resolves when quit() rejects and the forced disconnect throws', async () => {
+    const disconnect = mock.fn(() => { throw new Error('connection already broken') })
+    const client = { quit: () => Promise.reject(new Error('Connection is closed.')), disconnect } as unknown as Redis
+    const onTimeout = mock.fn()
+
+    await assert.doesNotReject(quitWithTimeout(client, 200, onTimeout))
+
+    assert.strictEqual(disconnect.mock.callCount(), 1)
+    assert.strictEqual(onTimeout.mock.callCount(), 0)
+  })
+
+  it('ignores a late quit() rejection that arrives after the timeout already resolved', async () => {
+    let rejectQuit: ((err: Error) => void) | undefined
+    const { client, disconnect } = fakeClient(() => new Promise((_resolve, reject) => { rejectQuit = reject }))
+    const onTimeout = mock.fn()
+
+    await quitWithTimeout(client, 20, onTimeout)
+    assert.strictEqual(disconnect.mock.callCount(), 1)
+
+    assert.doesNotThrow(() => rejectQuit?.(new Error('Connection is closed.')))
+    assert.strictEqual(disconnect.mock.callCount(), 1)
+  })
+})


### PR DESCRIPTION
 Bound `RedisMessageBroker.close()` with a timeout and forced-disconnect fallback so `app.close()` never hangs during a Redis outage.