### PR TITLE
feat(auth): add canAccessTool per request tool authorization hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1457,8 +1457,8 @@ await app.register(mcpPlugin, {
 
 The hook receives the tool name and a per-request context (`authContext`, `request`, `sessionId`), and may be sync or async. It is consulted at both dispatch points, so list and call can never disagree:
 
-- `tools/list` omits every tool the hook denies for that request. Independent per-tool checks run concurrently; the listing keeps registration order.
-- `tools/call` on a denied tool returns the same `-32601` "Tool 'name' not found" protocol error as an unknown tool, and the hook runs even for unknown names, so callers cannot probe for tools they are not allowed to see — by response shape or by timing. Task-augmented calls (`task` field) go through the same gate.
+- `tools/list` omits every tool the hook denies for that request. Per-tool checks run concurrently with a fixed cap (8 at a time), so an async hook backed by a database or HTTP service is not flooded with one lookup per registered tool; the listing keeps registration order.
+- `tools/call` on a denied tool returns the same `-32601` "Tool 'name' not found" protocol error as an unknown tool, and the hook runs even for unknown names, so callers cannot probe for tools they are not allowed to see by response shape. Response timing is not guaranteed to be indistinguishable — it depends on what the hook itself does per name. Task-augmented calls (`task` field) go through the same gate.
 
 A hook that throws denies access (fail closed) and logs a warning. Only an explicit `true` grants access. Without the hook, every registered tool stays visible and callable.
 

--- a/README.md
+++ b/README.md
@@ -1446,8 +1446,8 @@ Tool-level checks like the one above keep the tool visible to every client and o
 ```typescript
 await app.register(mcpPlugin, {
   authorization: { /* ... */ },
-  canAccessTool: (tool, { authContext }) => {
-    if (tool.name === 'admin-tool') {
+  canAccessTool: (toolName, { authContext }) => {
+    if (toolName === 'admin-tool') {
       return authContext?.scopes?.includes('tools:admin') === true
     }
     return true
@@ -1455,10 +1455,10 @@ await app.register(mcpPlugin, {
 })
 ```
 
-The hook receives the tool definition and a per-request context (`authContext`, `request`, `sessionId`), and may be sync or async. It is consulted at both dispatch points, so list and call can never disagree:
+The hook receives the tool name and a per-request context (`authContext`, `request`, `sessionId`), and may be sync or async. It is consulted at both dispatch points, so list and call can never disagree:
 
-- `tools/list` omits every tool the hook denies for that request.
-- `tools/call` on a denied tool returns the same `-32601` "Tool 'name' not found" protocol error as an unknown tool, so callers cannot probe for tools they are not allowed to see. Task-augmented calls (`task` field) go through the same gate.
+- `tools/list` omits every tool the hook denies for that request. Independent per-tool checks run concurrently; the listing keeps registration order.
+- `tools/call` on a denied tool returns the same `-32601` "Tool 'name' not found" protocol error as an unknown tool, and the hook runs even for unknown names, so callers cannot probe for tools they are not allowed to see — by response shape or by timing. Task-augmented calls (`task` field) go through the same gate.
 
 A hook that throws denies access (fail closed) and logs a warning. Only an explicit `true` grants access. Without the hook, every registered tool stays visible and callable.
 

--- a/README.md
+++ b/README.md
@@ -1439,6 +1439,29 @@ app.mcpAddTool({
 })
 ```
 
+### Per-Tool Authorization
+
+Tool-level checks like the one above keep the tool visible to every client and only fail at call time. To gate tools per request — hiding them from `tools/list` and rejecting `tools/call` in one place — provide a `canAccessTool` hook:
+
+```typescript
+await app.register(mcpPlugin, {
+  authorization: { /* ... */ },
+  canAccessTool: (tool, { authContext }) => {
+    if (tool.name === 'admin-tool') {
+      return authContext?.scopes?.includes('tools:admin') === true
+    }
+    return true
+  }
+})
+```
+
+The hook receives the tool definition and a per-request context (`authContext`, `request`, `sessionId`), and may be sync or async. It is consulted at both dispatch points, so list and call can never disagree:
+
+- `tools/list` omits every tool the hook denies for that request.
+- `tools/call` on a denied tool returns the same `-32601` "Tool 'name' not found" protocol error as an unknown tool, so callers cannot probe for tools they are not allowed to see. Task-augmented calls (`task` field) go through the same gate.
+
+A hook that throws denies access (fail closed) and logs a warning. Only an explicit `true` grants access. Without the hook, every registered tool stays visible and callable.
+
 ### OAuth Routes
 
 The plugin automatically registers OAuth management routes:
@@ -1658,6 +1681,7 @@ await app.register(import('@fastify/bearer-auth'), {
 - `capabilities`: MCP capabilities configuration
 - `instructions`: Optional server instructions
 - `enableSSE`: Enable Server-Sent Events support (default: false)
+- `canAccessTool`: Per-request tool authorization hook consulted by `tools/list` and `tools/call` (optional)
 - `authorization`: OAuth 2.1 authorization configuration (optional)
   - `enabled`: Enable OAuth 2.1 authorization (default: false)
   - `authorizationServers`: Authorization server URIs

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -177,12 +177,29 @@ async function checkToolAccess (toolName: string, dependencies: HandlerDependenc
   }
 }
 
+const TOOL_ACCESS_CONCURRENCY = 8
+
+async function mapWithConcurrency<T, R> (items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let next = 0
+  async function worker (): Promise<void> {
+    while (next < items.length) {
+      const index = next++
+      results[index] = await fn(items[index])
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker))
+  return results
+}
+
 async function handleToolsList (request: JSONRPCRequest, dependencies: HandlerDependencies): Promise<JSONRPCResponse> {
   const { tools, protocolVersion } = dependencies
-  // Independent per-tool checks run concurrently; order stays registration order
+  // Per-tool checks run concurrently (bounded); order stays registration order
   const registeredTools = Array.from(tools.values())
-  const accessResults = await Promise.all(
-    registeredTools.map(tool => checkToolAccess(tool.definition.name, dependencies))
+  const accessResults = await mapWithConcurrency(
+    registeredTools,
+    TOOL_ACCESS_CONCURRENCY,
+    tool => checkToolAccess(tool.definition.name, dependencies)
   )
   const accessibleTools = registeredTools.filter((_tool, index) => accessResults[index])
   const result: ListToolsResult = {
@@ -262,9 +279,10 @@ async function handleToolsCall (
   const toolName = params.name
 
   // A denied tool answers exactly like an unknown one, so a caller cannot
-  // distinguish "does not exist" from "exists but not for you" (mirrors the
-  // tools/list filtering). The hook runs even for unknown names, so both paths
-  // share the same timing and a caller cannot probe existence by latency.
+  // distinguish "does not exist" from "exists but not for you" by the protocol
+  // response (mirrors the tools/list filtering). The hook runs even for
+  // unknown names. No timing guarantee: latency depends on what the hook
+  // itself does per name.
   // Authorization is a protocol-level rejection, not a SEP-1303 tool error:
   // the model cannot correct itself out of missing access.
   const isAllowed = await checkToolAccess(toolName, dependencies)

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -153,10 +153,40 @@ function withSchemaDialect<T> (schema: T, protocolVersion: string | undefined): 
   return { $schema: JSON_SCHEMA_DIALECT, ...(schema as Record<string, unknown>) } as T
 }
 
-function handleToolsList (request: JSONRPCRequest, dependencies: HandlerDependencies): JSONRPCResponse {
+/**
+ * Evaluate the `canAccessTool` hook for one tool. No hook means every tool is
+ * accessible. A hook that throws denies access (fail closed) rather than
+ * exposing a tool the deployment meant to gate; the error is logged so a
+ * misbehaving hook is visible to the operator.
+ */
+async function checkToolAccess (tool: MCPTool, dependencies: HandlerDependencies): Promise<boolean> {
+  const hook = dependencies.opts.canAccessTool
+  if (!hook) return true
+  try {
+    return await hook(tool.definition, {
+      authContext: dependencies.authContext,
+      request: dependencies.request,
+      sessionId: dependencies.sessionId
+    }) === true
+  } catch (error) {
+    dependencies.app.log.warn({
+      err: error,
+      tool: tool.definition.name
+    }, 'canAccessTool hook threw; denying access')
+    return false
+  }
+}
+
+async function handleToolsList (request: JSONRPCRequest, dependencies: HandlerDependencies): Promise<JSONRPCResponse> {
   const { tools, protocolVersion } = dependencies
+  const accessibleTools: MCPTool[] = []
+  for (const tool of tools.values()) {
+    if (await checkToolAccess(tool, dependencies)) {
+      accessibleTools.push(tool)
+    }
+  }
   const result: ListToolsResult = {
-    tools: Array.from(tools.values()).map(t => {
+    tools: accessibleTools.map(t => {
       const tool = trimDefinitionToRevision(t.definition, protocolVersion)
       // TypeBox schemas are already JSON Schema compatible
       const serialized: typeof tool = {
@@ -232,7 +262,11 @@ async function handleToolsCall (
   const toolName = params.name
 
   const tool = tools.get(toolName)
-  if (!tool) {
+  // A denied tool answers exactly like an unknown one, so a caller cannot
+  // distinguish "does not exist" from "exists but not for you" (mirrors the
+  // tools/list filtering). Authorization is a protocol-level rejection, not a
+  // SEP-1303 tool error: the model cannot correct itself out of missing access.
+  if (!tool || !(await checkToolAccess(tool, dependencies))) {
     return createError(request.id, METHOD_NOT_FOUND, `Tool '${toolName}' not found`)
   }
 
@@ -1108,7 +1142,7 @@ export async function handleRequest (
       case 'ping':
         return handlePing(request)
       case 'tools/list':
-        return handleToolsList(request, dependencies)
+        return await handleToolsList(request, dependencies)
       case 'resources/list':
         return handleResourcesList(request, dependencies)
       case 'resources/templates/list':

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -159,19 +159,19 @@ function withSchemaDialect<T> (schema: T, protocolVersion: string | undefined): 
  * exposing a tool the deployment meant to gate; the error is logged so a
  * misbehaving hook is visible to the operator.
  */
-async function checkToolAccess (tool: MCPTool, dependencies: HandlerDependencies): Promise<boolean> {
+async function checkToolAccess (toolName: string, dependencies: HandlerDependencies): Promise<boolean> {
   const hook = dependencies.opts.canAccessTool
   if (!hook) return true
   try {
-    return await hook(tool.definition, {
+    return await hook(toolName, {
       authContext: dependencies.authContext,
       request: dependencies.request,
       sessionId: dependencies.sessionId
     }) === true
   } catch (error) {
-    dependencies.app.log.warn({
+    dependencies.request.log.warn({
       err: error,
-      tool: tool.definition.name
+      tool: toolName
     }, 'canAccessTool hook threw; denying access')
     return false
   }
@@ -179,12 +179,12 @@ async function checkToolAccess (tool: MCPTool, dependencies: HandlerDependencies
 
 async function handleToolsList (request: JSONRPCRequest, dependencies: HandlerDependencies): Promise<JSONRPCResponse> {
   const { tools, protocolVersion } = dependencies
-  const accessibleTools: MCPTool[] = []
-  for (const tool of tools.values()) {
-    if (await checkToolAccess(tool, dependencies)) {
-      accessibleTools.push(tool)
-    }
-  }
+  // Independent per-tool checks run concurrently; order stays registration order
+  const registeredTools = Array.from(tools.values())
+  const accessResults = await Promise.all(
+    registeredTools.map(tool => checkToolAccess(tool.definition.name, dependencies))
+  )
+  const accessibleTools = registeredTools.filter((_tool, index) => accessResults[index])
   const result: ListToolsResult = {
     tools: accessibleTools.map(t => {
       const tool = trimDefinitionToRevision(t.definition, protocolVersion)
@@ -261,12 +261,15 @@ async function handleToolsCall (
   const params = paramsValidation.data
   const toolName = params.name
 
-  const tool = tools.get(toolName)
   // A denied tool answers exactly like an unknown one, so a caller cannot
   // distinguish "does not exist" from "exists but not for you" (mirrors the
-  // tools/list filtering). Authorization is a protocol-level rejection, not a
-  // SEP-1303 tool error: the model cannot correct itself out of missing access.
-  if (!tool || !(await checkToolAccess(tool, dependencies))) {
+  // tools/list filtering). The hook runs even for unknown names, so both paths
+  // share the same timing and a caller cannot probe existence by latency.
+  // Authorization is a protocol-level rejection, not a SEP-1303 tool error:
+  // the model cannot correct itself out of missing access.
+  const isAllowed = await checkToolAccess(toolName, dependencies)
+  const tool = tools.get(toolName)
+  if (!isAllowed || !tool) {
     return createError(request.id, METHOD_NOT_FOUND, `Tool '${toolName}' not found`)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,7 @@ export type {
 // Export plugin types
 export type {
   MCPPluginOptions,
+  ToolAccessContext,
   MCPTool,
   MCPResource,
   MCPPrompt,

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,13 @@ export interface UnsafeMCPPrompt {
   handler?: UnsafePromptHandler
 }
 
+/** Per-request context handed to the `canAccessTool` hook. */
+export interface ToolAccessContext {
+  authContext?: AuthorizationContext
+  request: FastifyRequest
+  sessionId?: string
+}
+
 export interface MCPPluginOptions {
   serverInfo?: Implementation
   capabilities?: ServerCapabilities
@@ -206,15 +213,17 @@ export interface MCPPluginOptions {
    */
   allowedOrigins?: AllowedOrigins
   /**
-   * Per-request tool authorization. Consulted by both `tools/list` (a denied
-   * tool is omitted) and `tools/call` (a denied tool answers with the same
-   * "not found" error as an unknown tool, so callers cannot probe for tools
-   * they are not allowed to see). A hook that throws denies access.
+   * Per-request tool authorization, keyed by tool name. Consulted by both
+   * `tools/list` (a denied tool is omitted) and `tools/call` (a denied tool
+   * answers with the same "not found" error as an unknown tool, so callers
+   * cannot probe for tools they are not allowed to see). `tools/call` runs the
+   * hook even for unknown names, so denied and unknown calls share one code
+   * path and timing. A hook that throws denies access.
    * Omit to keep every registered tool visible and callable.
    */
   canAccessTool?: (
-    tool: Tool,
-    context: { authContext?: AuthorizationContext, request?: FastifyRequest, sessionId?: string }
+    toolName: string,
+    context: ToolAccessContext
   ) => boolean | Promise<boolean>
   sessionStore?: 'memory' | 'redis'
   messageBroker?: 'memory' | 'redis'

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,9 +216,10 @@ export interface MCPPluginOptions {
    * Per-request tool authorization, keyed by tool name. Consulted by both
    * `tools/list` (a denied tool is omitted) and `tools/call` (a denied tool
    * answers with the same "not found" error as an unknown tool, so callers
-   * cannot probe for tools they are not allowed to see). `tools/call` runs the
-   * hook even for unknown names, so denied and unknown calls share one code
-   * path and timing. A hook that throws denies access.
+   * cannot probe for tools they are not allowed to see by response shape).
+   * `tools/call` runs the hook even for unknown names. Response timing is not
+   * guaranteed to be indistinguishable: it depends on what the hook itself
+   * does per name. A hook that throws denies access.
    * Omit to keep every registered tool visible and callable.
    */
   canAccessTool?: (

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,6 +205,17 @@ export interface MCPPluginOptions {
    * to accept any origin, or list exact origins to allow.
    */
   allowedOrigins?: AllowedOrigins
+  /**
+   * Per-request tool authorization. Consulted by both `tools/list` (a denied
+   * tool is omitted) and `tools/call` (a denied tool answers with the same
+   * "not found" error as an unknown tool, so callers cannot probe for tools
+   * they are not allowed to see). A hook that throws denies access.
+   * Omit to keep every registered tool visible and callable.
+   */
+  canAccessTool?: (
+    tool: Tool,
+    context: { authContext?: AuthorizationContext, request?: FastifyRequest, sessionId?: string }
+  ) => boolean | Promise<boolean>
   sessionStore?: 'memory' | 'redis'
   messageBroker?: 'memory' | 'redis'
   redis?: {

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -288,6 +288,7 @@ expectType<() => Promise<void>>(RedisMessageBroker.prototype.close)
 // Constructor still requires a real Redis instance, not an arbitrary object
 expectError(new RedisMessageBroker({}))
 
+<<<<<<< Updated upstream
 // ─── Session stores ─────────────────────────────────────────────────
 
 // Both session store implementations are importable from the package root
@@ -306,3 +307,23 @@ expectType<(sessionId: string) => Promise<void>>(RedisSessionStore.prototype.del
 // Constructor still requires a real Redis instance, not an arbitrary object
 expectError(new RedisSessionStore({}))
 expectError(new RedisSessionStore())
+=======
+// ─── canAccessTool hook ─────────────────────────────────────────────
+
+// Hook parameters are fully typed: definition plus per-request context
+const accessHook: NonNullable<MCPPluginOptions['canAccessTool']> = (tool, context) => {
+  expectType<string>(tool.name)
+  expectAssignable<string[] | undefined>(context.authContext?.scopes)
+  expectAssignable<string | undefined>(context.sessionId)
+  return context.request !== undefined
+}
+expectAssignable<MCPPluginOptions>({ canAccessTool: accessHook })
+
+// Sync and async hooks are both accepted
+expectAssignable<MCPPluginOptions>({ canAccessTool: () => true })
+expectAssignable<MCPPluginOptions>({ canAccessTool: async () => false })
+
+// Non-boolean returns and non-function values are rejected
+expectNotAssignable<MCPPluginOptions>({ canAccessTool: () => 'yes' })
+expectNotAssignable<MCPPluginOptions>({ canAccessTool: true })
+>>>>>>> Stashed changes

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -5,7 +5,7 @@ import {
   expectNotAssignable,
 } from 'tsd'
 import { Type } from '@sinclair/typebox'
-import type { FastifyReply } from 'fastify'
+import type { FastifyReply, FastifyRequest } from 'fastify'
 import { RedisMessageBroker, MemoryMessageBroker, RedisSessionStore, MemorySessionStore } from '../dist/index.js'
 import type {
   ToolHandler,
@@ -26,6 +26,7 @@ import type {
   MessageBroker,
   SessionStore,
   SessionMetadata,
+  ToolAccessContext,
 } from '../dist/index.js'
 
 // ─── ToolHandler ─────────────────────────────────────────────────────
@@ -288,7 +289,6 @@ expectType<() => Promise<void>>(RedisMessageBroker.prototype.close)
 // Constructor still requires a real Redis instance, not an arbitrary object
 expectError(new RedisMessageBroker({}))
 
-<<<<<<< Updated upstream
 // ─── Session stores ─────────────────────────────────────────────────
 
 // Both session store implementations are importable from the package root
@@ -307,17 +307,21 @@ expectType<(sessionId: string) => Promise<void>>(RedisSessionStore.prototype.del
 // Constructor still requires a real Redis instance, not an arbitrary object
 expectError(new RedisSessionStore({}))
 expectError(new RedisSessionStore())
-=======
+
 // ─── canAccessTool hook ─────────────────────────────────────────────
 
-// Hook parameters are fully typed: definition plus per-request context
-const accessHook: NonNullable<MCPPluginOptions['canAccessTool']> = (tool, context) => {
-  expectType<string>(tool.name)
+// Hook parameters are fully typed: tool name plus per-request context
+const accessHook: NonNullable<MCPPluginOptions['canAccessTool']> = (toolName, context) => {
+  expectType<string>(toolName)
   expectAssignable<string[] | undefined>(context.authContext?.scopes)
   expectAssignable<string | undefined>(context.sessionId)
   return context.request !== undefined
 }
 expectAssignable<MCPPluginOptions>({ canAccessTool: accessHook })
+
+// The context type is exported and carries a required request
+expectAssignable<ToolAccessContext>({ request: {} as FastifyRequest })
+expectNotAssignable<ToolAccessContext>({})
 
 // Sync and async hooks are both accepted
 expectAssignable<MCPPluginOptions>({ canAccessTool: () => true })
@@ -326,4 +330,3 @@ expectAssignable<MCPPluginOptions>({ canAccessTool: async () => false })
 // Non-boolean returns and non-function values are rejected
 expectNotAssignable<MCPPluginOptions>({ canAccessTool: () => 'yes' })
 expectNotAssignable<MCPPluginOptions>({ canAccessTool: true })
->>>>>>> Stashed changes

--- a/test/tool-authorization.test.ts
+++ b/test/tool-authorization.test.ts
@@ -1,0 +1,235 @@
+import { test, describe } from 'node:test'
+import type { TestContext } from 'node:test'
+import Fastify from 'fastify'
+import mcpPlugin from '../src/index.ts'
+import type { MCPPluginOptions } from '../src/types.ts'
+import type { JSONRPCRequest, JSONRPCResultResponse, JSONRPCErrorResponse, ListToolsResult } from '../src/schema.ts'
+import { JSONRPC_VERSION, METHOD_NOT_FOUND } from '../src/schema.ts'
+import { createTestJWT, setupMockAgent, generateMockJWKSResponse, createTestAuthConfig } from './auth-test-utils.ts'
+
+async function buildApp (t: TestContext, opts: MCPPluginOptions = {}) {
+  const app = Fastify({ logger: false })
+  t.after(() => app.close())
+  await app.register(mcpPlugin, opts)
+
+  app.mcpAddTool({
+    name: 'public-tool',
+    description: 'Tool everyone can use',
+    inputSchema: { type: 'object', properties: {} }
+  }, async () => ({ content: [{ type: 'text', text: 'public ok' }] }))
+
+  app.mcpAddTool({
+    name: 'restricted-tool',
+    description: 'Tool behind authorization',
+    inputSchema: { type: 'object', properties: {} }
+  }, async () => ({ content: [{ type: 'text', text: 'restricted ok' }] }))
+
+  await app.ready()
+  return app
+}
+
+function listRequest (id = 1): JSONRPCRequest {
+  return { jsonrpc: JSONRPC_VERSION, id, method: 'tools/list' }
+}
+
+function callRequest (name: string, id = 1): JSONRPCRequest {
+  return {
+    jsonrpc: JSONRPC_VERSION,
+    id,
+    method: 'tools/call',
+    params: { name, arguments: {} }
+  }
+}
+
+function listedToolNames (response: { json: () => unknown }): string[] {
+  const body = response.json() as JSONRPCResultResponse
+  return (body.result as ListToolsResult).tools.map(t => t.name)
+}
+
+describe('Tool Authorization (canAccessTool)', () => {
+  test('without a hook, every tool is listed and callable', async (t: TestContext) => {
+    const app = await buildApp(t)
+
+    const listResponse = await app.inject({ method: 'POST', url: '/mcp', payload: listRequest() })
+    t.assert.strictEqual(listResponse.statusCode, 200)
+    t.assert.deepStrictEqual(listedToolNames(listResponse), ['public-tool', 'restricted-tool'])
+
+    const callResponse = await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('restricted-tool') })
+    const callBody = callResponse.json() as JSONRPCResultResponse
+    t.assert.ok(callBody.result, 'call should succeed without a hook')
+  })
+
+  test('tools/list omits tools the hook denies, per request', async (t: TestContext) => {
+    const app = await buildApp(t, {
+      canAccessTool: (tool, context) => {
+        if (tool.name !== 'restricted-tool') return true
+        return context.request?.headers['x-role'] === 'admin'
+      }
+    })
+
+    const memberResponse = await app.inject({ method: 'POST', url: '/mcp', payload: listRequest() })
+    t.assert.deepStrictEqual(listedToolNames(memberResponse), ['public-tool'])
+
+    const adminResponse = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: listRequest(),
+      headers: { 'x-role': 'admin' }
+    })
+    t.assert.deepStrictEqual(listedToolNames(adminResponse), ['public-tool', 'restricted-tool'])
+  })
+
+  test('tools/call to a denied tool answers exactly like an unknown tool', async (t: TestContext) => {
+    let handlerInvoked = false
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin, { canAccessTool: (tool) => tool.name !== 'restricted-tool' })
+    app.mcpAddTool({
+      name: 'restricted-tool',
+      description: 'Tool behind authorization',
+      inputSchema: { type: 'object', properties: {} }
+    }, async () => {
+      handlerInvoked = true
+      return { content: [{ type: 'text', text: 'restricted ok' }] }
+    })
+    await app.ready()
+
+    const deniedResponse = await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('restricted-tool') })
+    const deniedBody = deniedResponse.json() as JSONRPCErrorResponse
+    const unknownResponse = await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('no-such-tool') })
+    const unknownBody = unknownResponse.json() as JSONRPCErrorResponse
+
+    t.assert.strictEqual(handlerInvoked, false, 'denied handler must not run')
+    t.assert.strictEqual(deniedBody.error.code, METHOD_NOT_FOUND)
+    t.assert.strictEqual(deniedBody.error.message, "Tool 'restricted-tool' not found")
+    // Same code and message shape as a genuinely unknown tool: no existence leak
+    t.assert.strictEqual(unknownBody.error.code, deniedBody.error.code)
+    t.assert.strictEqual(unknownBody.error.message, "Tool 'no-such-tool' not found")
+  })
+
+  test('async hooks are awaited', async (t: TestContext) => {
+    const app = await buildApp(t, {
+      canAccessTool: async (tool) => {
+        await new Promise(resolve => setImmediate(resolve))
+        return tool.name === 'public-tool'
+      }
+    })
+
+    const listResponse = await app.inject({ method: 'POST', url: '/mcp', payload: listRequest() })
+    t.assert.deepStrictEqual(listedToolNames(listResponse), ['public-tool'])
+
+    const callResponse = await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('restricted-tool') })
+    const callBody = callResponse.json() as JSONRPCErrorResponse
+    t.assert.strictEqual(callBody.error.code, METHOD_NOT_FOUND)
+  })
+
+  test('a throwing hook fails closed', async (t: TestContext) => {
+    const app = await buildApp(t, {
+      canAccessTool: () => {
+        throw new Error('authorization backend unavailable')
+      }
+    })
+
+    const listResponse = await app.inject({ method: 'POST', url: '/mcp', payload: listRequest() })
+    t.assert.strictEqual(listResponse.statusCode, 200, 'a hook failure must not become an HTTP error')
+    t.assert.deepStrictEqual(listedToolNames(listResponse), [])
+
+    const callResponse = await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('public-tool') })
+    const callBody = callResponse.json() as JSONRPCErrorResponse
+    t.assert.strictEqual(callBody.error.code, METHOD_NOT_FOUND)
+  })
+
+  test('non-boolean truthy returns deny access', async (t: TestContext) => {
+    // A hook typed away from strictness (e.g. plain JS) returning a truthy
+    // non-boolean must not accidentally grant access
+    const app = await buildApp(t, {
+      canAccessTool: (() => 'yes') as unknown as MCPPluginOptions['canAccessTool']
+    })
+
+    const listResponse = await app.inject({ method: 'POST', url: '/mcp', payload: listRequest() })
+    t.assert.deepStrictEqual(listedToolNames(listResponse), [])
+  })
+
+  test('task-augmented calls inherit the gate', async (t: TestContext) => {
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin, {
+      enableTasks: true,
+      canAccessTool: (tool) => tool.name !== 'restricted-task-tool'
+    })
+    app.mcpAddTool({
+      name: 'restricted-task-tool',
+      description: 'Task-capable tool behind authorization',
+      inputSchema: { type: 'object', properties: {} },
+      execution: { taskSupport: 'optional' }
+    }, async () => ({ content: [{ type: 'text', text: 'should never run' }] }))
+    await app.ready()
+
+    const taskCallResponse = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { 'mcp-protocol-version': '2025-11-25' },
+      payload: {
+        jsonrpc: JSONRPC_VERSION,
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'restricted-task-tool', arguments: {}, task: {} }
+      }
+    })
+    const taskCallBody = taskCallResponse.json() as JSONRPCErrorResponse
+    t.assert.strictEqual(taskCallBody.error.code, METHOD_NOT_FOUND)
+    t.assert.strictEqual(taskCallBody.error.message, "Tool 'restricted-task-tool' not found")
+  })
+
+  test('hook receives the authContext of the calling token', async (t: TestContext) => {
+    const restoreMock = setupMockAgent({
+      'https://auth.example.com/.well-known/jwks.json': generateMockJWKSResponse()
+    })
+    t.after(() => restoreMock())
+
+    const app = await buildApp(t, {
+      authorization: createTestAuthConfig({ resourceUri: 'http://localhost:3000' }),
+      canAccessTool: (tool, context) => {
+        if (tool.name !== 'restricted-tool') return true
+        return context.authContext?.scopes?.includes('tools:admin') === true
+      }
+    })
+
+    const withScope = createTestJWT({ aud: 'http://localhost:3000', scope: 'tools:read tools:admin' } as any)
+    const withoutScope = createTestJWT({ aud: 'http://localhost:3000', scope: 'tools:read' } as any)
+
+    const adminList = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { authorization: `Bearer ${withScope}` },
+      payload: listRequest()
+    })
+    t.assert.deepStrictEqual(listedToolNames(adminList), ['public-tool', 'restricted-tool'])
+
+    const readerList = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { authorization: `Bearer ${withoutScope}` },
+      payload: listRequest()
+    })
+    t.assert.deepStrictEqual(listedToolNames(readerList), ['public-tool'])
+
+    const readerCall = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { authorization: `Bearer ${withoutScope}` },
+      payload: callRequest('restricted-tool')
+    })
+    const readerCallBody = readerCall.json() as JSONRPCErrorResponse
+    t.assert.strictEqual(readerCallBody.error.code, METHOD_NOT_FOUND)
+
+    const adminCall = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { authorization: `Bearer ${withScope}` },
+      payload: callRequest('restricted-tool')
+    })
+    const adminCallBody = adminCall.json() as JSONRPCResultResponse
+    t.assert.ok(adminCallBody.result, 'holder of the required scope can call the tool')
+  })
+})

--- a/test/tool-authorization.test.ts
+++ b/test/tool-authorization.test.ts
@@ -61,9 +61,9 @@ describe('Tool Authorization (canAccessTool)', () => {
 
   test('tools/list omits tools the hook denies, per request', async (t: TestContext) => {
     const app = await buildApp(t, {
-      canAccessTool: (tool, context) => {
-        if (tool.name !== 'restricted-tool') return true
-        return context.request?.headers['x-role'] === 'admin'
+      canAccessTool: (toolName, context) => {
+        if (toolName !== 'restricted-tool') return true
+        return context.request.headers['x-role'] === 'admin'
       }
     })
 
@@ -83,7 +83,7 @@ describe('Tool Authorization (canAccessTool)', () => {
     let handlerInvoked = false
     const app = Fastify({ logger: false })
     t.after(() => app.close())
-    await app.register(mcpPlugin, { canAccessTool: (tool) => tool.name !== 'restricted-tool' })
+    await app.register(mcpPlugin, { canAccessTool: (toolName) => toolName !== 'restricted-tool' })
     app.mcpAddTool({
       name: 'restricted-tool',
       description: 'Tool behind authorization',
@@ -107,11 +107,49 @@ describe('Tool Authorization (canAccessTool)', () => {
     t.assert.strictEqual(unknownBody.error.message, "Tool 'no-such-tool' not found")
   })
 
+  test('the hook is invoked for unknown tool names too', async (t: TestContext) => {
+    // Same code path for unknown and denied names: no timing-based existence leak
+    const checkedNames: string[] = []
+    const app = await buildApp(t, {
+      canAccessTool: async (toolName) => {
+        checkedNames.push(toolName)
+        await new Promise(resolve => setImmediate(resolve))
+        return toolName !== 'restricted-tool'
+      }
+    })
+
+    await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('restricted-tool') })
+    await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('no-such-tool') })
+
+    t.assert.ok(checkedNames.includes('restricted-tool'), 'denied registered name must be checked')
+    t.assert.ok(checkedNames.includes('no-such-tool'), 'unknown name must be checked')
+  })
+
+  test('tools/list evaluates independent checks concurrently', async (t: TestContext) => {
+    let activeChecks = 0
+    let maxConcurrentChecks = 0
+    const app = await buildApp(t, {
+      canAccessTool: async () => {
+        activeChecks++
+        maxConcurrentChecks = Math.max(maxConcurrentChecks, activeChecks)
+        await new Promise(resolve => setImmediate(resolve))
+        activeChecks--
+        return true
+      }
+    })
+
+    const listResponse = await app.inject({ method: 'POST', url: '/mcp', payload: listRequest() })
+    // buildApp registers two tools; serial evaluation would report 1
+    t.assert.strictEqual(maxConcurrentChecks, 2)
+    // Concurrency must not reorder: registration order is preserved
+    t.assert.deepStrictEqual(listedToolNames(listResponse), ['public-tool', 'restricted-tool'])
+  })
+
   test('async hooks are awaited', async (t: TestContext) => {
     const app = await buildApp(t, {
-      canAccessTool: async (tool) => {
+      canAccessTool: async (toolName) => {
         await new Promise(resolve => setImmediate(resolve))
-        return tool.name === 'public-tool'
+        return toolName === 'public-tool'
       }
     })
 
@@ -155,7 +193,7 @@ describe('Tool Authorization (canAccessTool)', () => {
     t.after(() => app.close())
     await app.register(mcpPlugin, {
       enableTasks: true,
-      canAccessTool: (tool) => tool.name !== 'restricted-task-tool'
+      canAccessTool: (toolName) => toolName !== 'restricted-task-tool'
     })
     app.mcpAddTool({
       name: 'restricted-task-tool',
@@ -189,8 +227,8 @@ describe('Tool Authorization (canAccessTool)', () => {
 
     const app = await buildApp(t, {
       authorization: createTestAuthConfig({ resourceUri: 'http://localhost:3000' }),
-      canAccessTool: (tool, context) => {
-        if (tool.name !== 'restricted-tool') return true
+      canAccessTool: (toolName, context) => {
+        if (toolName !== 'restricted-tool') return true
         return context.authContext?.scopes?.includes('tools:admin') === true
       }
     })

--- a/test/tool-authorization.test.ts
+++ b/test/tool-authorization.test.ts
@@ -108,7 +108,7 @@ describe('Tool Authorization (canAccessTool)', () => {
   })
 
   test('the hook is invoked for unknown tool names too', async (t: TestContext) => {
-    // Same code path for unknown and denied names: no timing-based existence leak
+    // Same code path for unknown and denied names: identical protocol response
     const checkedNames: string[] = []
     const app = await buildApp(t, {
       canAccessTool: async (toolName) => {
@@ -143,6 +143,48 @@ describe('Tool Authorization (canAccessTool)', () => {
     t.assert.strictEqual(maxConcurrentChecks, 2)
     // Concurrency must not reorder: registration order is preserved
     t.assert.deepStrictEqual(listedToolNames(listResponse), ['public-tool', 'restricted-tool'])
+  })
+
+  test('tools/list caps concurrent hook evaluations with many tools', async (t: TestContext) => {
+    const TOOL_COUNT = 50
+    const CONCURRENCY_CAP = 8
+    let activeChecks = 0
+    let maxConcurrentChecks = 0
+    let totalChecks = 0
+    const app = Fastify({ logger: false })
+    t.after(() => app.close())
+    await app.register(mcpPlugin, {
+      canAccessTool: async () => {
+        activeChecks++
+        totalChecks++
+        maxConcurrentChecks = Math.max(maxConcurrentChecks, activeChecks)
+        await new Promise(resolve => setImmediate(resolve))
+        activeChecks--
+        return true
+      }
+    })
+    for (let i = 0; i < TOOL_COUNT; i++) {
+      app.mcpAddTool({
+        name: `tool-${i}`,
+        description: `Tool number ${i}`,
+        inputSchema: { type: 'object', properties: {} }
+      }, async () => ({ content: [{ type: 'text', text: 'ok' }] }))
+    }
+    await app.ready()
+
+    const listResponse = await app.inject({ method: 'POST', url: '/mcp', payload: listRequest() })
+
+    t.assert.strictEqual(totalChecks, TOOL_COUNT, 'every tool must be checked')
+    t.assert.ok(maxConcurrentChecks > 1, 'checks must overlap')
+    t.assert.ok(
+      maxConcurrentChecks <= CONCURRENCY_CAP,
+      `at most ${CONCURRENCY_CAP} concurrent checks, saw ${maxConcurrentChecks}`
+    )
+    // Registration order preserved despite the bounded pool
+    t.assert.deepStrictEqual(
+      listedToolNames(listResponse),
+      Array.from({ length: TOOL_COUNT }, (_, i) => `tool-${i}`)
+    )
   })
 
   test('async hooks are awaited', async (t: TestContext) => {


### PR DESCRIPTION
Add an optional `canAccessTool` plugin hook that gates tools per request at both `tools/list` (denied tools are omitted) and `tools/call` (denial returns the same not-found error as an unknown tool, closing the existence-probe side channel), failing closed when the hook throws.