### PR TITLE
feat(tools): add in process tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1796,6 +1796,32 @@ app.mcpAddTool(
 )
 ```
 
+#### Server-Side Tool Invocation
+
+Use `app.mcpCallTool()` when application code needs to run a registered tool without making a loopback `POST /mcp` request or building a JSON-RPC envelope. The call uses the same tool registry, input validation, `canAccessTool` hook, argument sanitization, required task execution check and handler error conversion as `tools/call`, but it does not create or use an MCP session, SSE stream, message broker or Redis connection. `mcpCallTool()` executes the tool access, validation, sanitization, and handler pipeline. It does not run Fastify lifecycle hooks and is only available in the Fastify encapsulation scope where the MCP plugin was registered and its descendants.
+
+```typescript
+const outcome = await app.mcpCallTool('search', { query: 'fastify' }, { request, reply })
+
+if (outcome.ok) {
+  return outcome.result
+}
+
+switch (outcome.reason) {
+  case 'not-found':
+    reply.code(404)
+    return { error: 'Tool not found' }
+  case 'invalid-arguments':
+    reply.code(400)
+    return { error: outcome.detail }
+  case 'task-required':
+    reply.code(409)
+    return { error: 'Tool must be invoked through task-augmented tools/call' }
+}
+```
+
+The `canAccessTool` hook still runs before validation and before the handler, and receives the same `request` object passed to `mcpCallTool()`. Denied tools and unknown tools both return `{ ok: false, reason: 'not-found' }`, matching the JSON-RPC `tools/call` path's public behavior. Pass the route's real `reply` so tool handlers can use the full Fastify reply API. Pass `authContext` when the in-process caller has one so access hooks and handlers see the same authorization context they would receive over HTTP. If the tool handler throws, the outcome is `{ ok: true, result }` with `result.isError: true`, matching the JSON-RPC `tools/call` path.
+
 #### Type-Safe Resource Registration
 
 ```typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fastify/type-provider-typebox": "^6.0.0",
         "ajv": "^8.17.1",
         "fast-jwt": "^6.0.2",
+        "fastify-error": "^0.3.1",
         "fastify-plugin": "^6.0.0",
         "get-jwks": "^11.0.1",
         "ioredis": "^5.0.0",
@@ -4755,6 +4756,12 @@
         "semver": "^7.6.0",
         "toad-cache": "^3.7.0"
       }
+    },
+    "node_modules/fastify-error": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.3.1.tgz",
+      "integrity": "sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ==",
+      "license": "MIT"
     },
     "node_modules/fastify-plugin": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@fastify/jwt": "^10.0.0",
     "@fastify/type-provider-typebox": "^6.0.0",
     "fast-jwt": "^6.0.2",
+    "fastify-error": "^0.3.1",
     "fastify-plugin": "^6.0.0",
     "get-jwks": "^11.0.1",
     "ioredis": "^5.0.0",

--- a/src/decorators/meta.ts
+++ b/src/decorators/meta.ts
@@ -4,10 +4,13 @@ import type {
   MCPTool,
   MCPResource,
   MCPPrompt,
+  MCPPluginOptions,
+  McpCallToolContext,
   ResourceHandlers,
   ResourceSubscribeHandler,
   ResourceUnsubscribeHandler
 } from '../types.ts'
+import { callRegisteredTool } from '../handlers.ts'
 import { schemaToArguments, validateToolSchema, isTypeBoxSchema } from '../validation/index.ts'
 import type { JsonSchemaValidator } from '../validation/json-schema-validator.ts'
 
@@ -16,11 +19,12 @@ interface MCPDecoratorsOptions {
   resources: Map<string, MCPResource>
   prompts: Map<string, MCPPrompt>
   resourceHandlers: ResourceHandlers
+  opts: MCPPluginOptions
   jsonSchemaValidator?: JsonSchemaValidator
 }
 
 const mcpDecoratorsPlugin: FastifyPluginAsync<MCPDecoratorsOptions> = async (app, options) => {
-  const { tools, resources, prompts, resourceHandlers, jsonSchemaValidator } = options
+  const { tools, resources, prompts, resourceHandlers, opts, jsonSchemaValidator } = options
 
   // Enhanced tool decorator with TypeBox schema support
   app.decorate('mcpAddTool', (
@@ -60,6 +64,18 @@ const mcpDecoratorsPlugin: FastifyPluginAsync<MCPDecoratorsOptions> = async (app
         inputSchema: definition.inputSchema || toolDefinition.inputSchema
       },
       handler
+    })
+  })
+
+  app.decorate('mcpCallTool', (name: string, args: Record<string, unknown>, context: McpCallToolContext) => {
+    return callRegisteredTool(name, args, {
+      app,
+      opts,
+      tools,
+      jsonSchemaValidator,
+      request: context.request,
+      reply: context.reply,
+      authContext: context.authContext
     })
   })
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
+import createFastifyError from 'fastify-error'
 import type {
   JSONRPCMessage,
   JSONRPCRequest,
@@ -30,7 +31,7 @@ import {
 } from './schema.ts'
 import type { RequestId } from './schema.ts'
 
-import type { MCPTool, MCPResource, MCPPrompt, MCPPluginOptions, ResourceHandlers } from './types.ts'
+import type { MCPTool, MCPResource, MCPPrompt, MCPPluginOptions, ResourceHandlers, McpCallToolOutcome } from './types.ts'
 import type { SessionStore } from './stores/session-store.ts'
 import type { TaskStore, TaskRecord, TaskWaiters } from './stores/task-store.ts'
 import { isTerminal, toWireTask } from './stores/task-store.ts'
@@ -65,6 +66,17 @@ type HandlerDependencies = {
   /** The revision this client negotiated; responses are shaped to match it */
   protocolVersion?: string
 }
+
+type ToolCallDependencies = Pick<HandlerDependencies,
+  'app' |
+  'opts' |
+  'tools' |
+  'request' |
+  'reply' |
+  'authContext' |
+  'jsonSchemaValidator' |
+  'sessionId'
+>
 
 export function createResponse (id: string | number, result: any): JSONRPCResponse {
   return {
@@ -161,7 +173,7 @@ function withSchemaDialect<T> (schema: T, protocolVersion: string | undefined): 
  * exposing a tool the deployment meant to gate; the error is logged so a
  * misbehaving hook is visible to the operator.
  */
-async function checkToolAccess (toolName: string, dependencies: HandlerDependencies): Promise<boolean> {
+async function checkToolAccess (toolName: string, dependencies: ToolCallDependencies): Promise<boolean> {
   const hook = dependencies.opts.canAccessTool
   if (!hook) return true
   try {
@@ -180,6 +192,11 @@ async function checkToolAccess (toolName: string, dependencies: HandlerDependenc
 }
 
 const TOOL_ACCESS_CONCURRENCY = 8
+
+const UnhandledToolCallOutcomeError = createFastifyError(
+  'MCP_ERR_UNHANDLED_TOOL_CALL_OUTCOME',
+  'Unhandled tool call outcome: %s'
+)
 
 async function mapWithConcurrency<T, R> (items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
   const results = new Array<R>(items.length)
@@ -267,8 +284,6 @@ async function handleToolsCall (
   sessionId: string | undefined,
   dependencies: HandlerDependencies
 ): Promise<JSONRPCResponse | JSONRPCError> {
-  const { tools } = dependencies
-
   // Validate the request parameters structure
   const paramsValidation = validate(CallToolRequestSchema, request.params)
   if (!paramsValidation.success) {
@@ -287,10 +302,9 @@ async function handleToolsCall (
   // itself does per name.
   // Authorization is a protocol-level rejection, not a SEP-1303 tool error:
   // the model cannot correct itself out of missing access.
-  const isAllowed = await checkToolAccess(toolName, dependencies)
-  const tool = tools.get(toolName)
-  if (!isAllowed || !tool) {
-    return createError(request.id, METHOD_NOT_FOUND, `Tool '${toolName}' not found`)
+  const resolved = await resolveRegisteredTool(toolName, dependencies)
+  if (!resolved.ok) {
+    return toolCallOutcomeToJsonRpc(request.id, toolName, resolved)
   }
 
   // Decide up front whether this call runs as a task, so the rest of the
@@ -300,7 +314,7 @@ async function handleToolsCall (
   const taskParams = supportsTasks(dependencies.protocolVersion)
     ? (request.params as { task?: { ttl?: number } } | undefined)?.task
     : undefined
-  const augmentation = resolveTaskAugmentation(tool, taskParams !== undefined)
+  const augmentation = resolveTaskAugmentation(resolved.tool, taskParams !== undefined)
   if ('error' in augmentation) {
     return createError(request.id, METHOD_NOT_FOUND, augmentation.error)
   }
@@ -308,12 +322,81 @@ async function handleToolsCall (
     return await runToolCallAsTask(
       request,
       taskParams?.ttl,
-      () => executeToolCall(request, tool, params, sessionId, dependencies),
+      () => executeToolCall(request, resolved.tool, params, sessionId, dependencies),
       dependencies
     )
   }
 
-  return await executeToolCall(request, tool, params, sessionId, dependencies)
+  return await executeToolCall(request, resolved.tool, params, sessionId, dependencies)
+}
+
+async function resolveRegisteredTool (
+  toolName: string,
+  dependencies: ToolCallDependencies
+): Promise<{ ok: true, tool: MCPTool } | { ok: false, reason: 'not-found' }> {
+  const isAllowed = await checkToolAccess(toolName, dependencies)
+  if (!isAllowed) {
+    return { ok: false, reason: 'not-found' }
+  }
+
+  const tool = dependencies.tools.get(toolName)
+  if (!tool) {
+    return { ok: false, reason: 'not-found' }
+  }
+
+  return { ok: true, tool }
+}
+
+function toolCallOutcomeToJsonRpc (
+  id: RequestId,
+  toolName: string,
+  outcome: McpCallToolOutcome
+): JSONRPCResponse | JSONRPCError {
+  if (outcome.ok) {
+    return createResponse(id, outcome.result)
+  }
+
+  switch (outcome.reason) {
+    case 'invalid-arguments': {
+      const result: CallToolResult = {
+        content: [{
+          type: 'text',
+          text: `Invalid tool arguments: ${outcome.detail}`
+        }],
+        isError: true
+      }
+      return createResponse(id, result)
+    }
+    case 'not-found':
+      return createError(id, METHOD_NOT_FOUND, `Tool '${toolName}' not found`)
+    // Unreachable from the JSON-RPC path today (handleToolsCall resolves task
+    // augmentation itself), but kept in the mapping so the two paths stay
+    // consistent if they ever converge. Mirrors resolveTaskAugmentation's error.
+    case 'task-required':
+      return createError(id, METHOD_NOT_FOUND, `Tool '${toolName}' requires task-augmented execution`)
+    default: {
+      const unhandled: never = outcome
+      throw new UnhandledToolCallOutcomeError(JSON.stringify(unhandled))
+    }
+  }
+}
+
+export async function callRegisteredTool (
+  name: string,
+  args: Record<string, unknown>,
+  dependencies: ToolCallDependencies
+): Promise<McpCallToolOutcome> {
+  const resolved = await resolveRegisteredTool(name, dependencies)
+  if (!resolved.ok) {
+    return resolved
+  }
+
+  const augmentation = resolveTaskAugmentation(resolved.tool, false)
+  if ('error' in augmentation) {
+    return { ok: false, reason: 'task-required' }
+  }
+
+  return await executeRegisteredTool(resolved.tool, name, args, dependencies)
 }
 
 async function executeToolCall (
@@ -325,6 +408,18 @@ async function executeToolCall (
 ): Promise<JSONRPCResponse | JSONRPCError> {
   const toolName = params.name
 
+  const outcome = await executeRegisteredTool(tool, toolName, params.arguments || {}, { ...dependencies, sessionId })
+  return toolCallOutcomeToJsonRpc(request.id, toolName, outcome)
+}
+
+async function executeRegisteredTool (
+  tool: MCPTool,
+  toolName: string,
+  args: Record<string, unknown>,
+  dependencies: ToolCallDependencies
+): Promise<McpCallToolOutcome> {
+  const sessionId = dependencies.sessionId
+
   if (!tool.handler) {
     const result: CallToolResult = {
       content: [{
@@ -333,7 +428,7 @@ async function executeToolCall (
       }],
       isError: true
     }
-    return createResponse(request.id, result)
+    return { ok: true, result }
   }
 
   // Assess security risks from tool annotations
@@ -349,7 +444,7 @@ async function executeToolCall (
   }
 
   // Validate and sanitize tool arguments against the tool's input schema
-  let toolArguments = params.arguments || {}
+  let toolArguments = args
 
   try {
     // Sanitize arguments to prevent injection attacks
@@ -370,7 +465,7 @@ async function executeToolCall (
       }],
       isError: true
     }
-    return createResponse(request.id, result)
+    return { ok: true, result }
   }
   if ('inputSchema' in tool.definition) {
     // Check if it's a TypeBox schema
@@ -379,20 +474,13 @@ async function executeToolCall (
       // TypeBox schema - use our validation
       const argumentsValidation = validate(schema, toolArguments)
       if (!argumentsValidation.success) {
-        const result: CallToolResult = {
-          content: [{
-            type: 'text',
-            text: `Invalid tool arguments: ${argumentsValidation.error.message}`
-          }],
-          isError: true
-        }
-        return createResponse(request.id, result)
+        return { ok: false, reason: 'invalid-arguments', detail: argumentsValidation.error.message }
       }
 
       // Use validated arguments
       try {
         const result = await tool.handler(argumentsValidation.data, { sessionId, request: dependencies.request, reply: dependencies.reply, authContext: dependencies.authContext })
-        return createResponse(request.id, result)
+        return { ok: true, result }
       } catch (error: any) {
         const result: CallToolResult = {
           content: [{
@@ -401,7 +489,7 @@ async function executeToolCall (
           }],
           isError: true
         }
-        return createResponse(request.id, result)
+        return { ok: true, result }
       }
     } else {
       // Regular JSON Schema - validated with AJV when opted in, pass through otherwise
@@ -410,19 +498,12 @@ async function executeToolCall (
         if (validationError !== null) {
           // SEP-1303: a tool execution error, not a protocol error (same as the
           // TypeBox branch above)
-          const result: CallToolResult = {
-            content: [{
-              type: 'text',
-              text: `Invalid tool arguments: ${validationError}`
-            }],
-            isError: true
-          }
-          return createResponse(request.id, result)
+          return { ok: false, reason: 'invalid-arguments', detail: validationError }
         }
       }
       try {
         const result = await tool.handler(toolArguments, { sessionId, request: dependencies.request, reply: dependencies.reply, authContext: dependencies.authContext })
-        return createResponse(request.id, result)
+        return { ok: true, result }
       } catch (error: any) {
         const result: CallToolResult = {
           content: [{
@@ -431,7 +512,7 @@ async function executeToolCall (
           }],
           isError: true
         }
-        return createResponse(request.id, result)
+        return { ok: true, result }
       }
     }
   } else {
@@ -443,7 +524,7 @@ async function executeToolCall (
         reply: dependencies.reply,
         authContext: dependencies.authContext
       })
-      return createResponse(request.id, result)
+      return { ok: true, result }
     } catch (error: any) {
       const result: CallToolResult = {
         content: [{
@@ -452,7 +533,7 @@ async function executeToolCall (
         }],
         isError: true
       }
-      return createResponse(request.id, result)
+      return { ok: true, result }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,7 @@ const mcpPlugin = fp(async function (app: FastifyInstance, opts: MCPPluginOption
     resources,
     prompts,
     resourceHandlers,
+    opts,
     jsonSchemaValidator
   })
   app.register(pubsubDecorators, {
@@ -261,6 +262,8 @@ export type {
   MCPRouteSchemaContext,
   MCPRouteSchemaTransformer,
   ToolAccessContext,
+  McpCallToolContext,
+  McpCallToolOutcome,
   MCPTool,
   MCPResource,
   MCPPrompt,

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,12 @@ declare module 'fastify' {
       handler?: UnsafeToolHandler
     ): void
 
+    mcpCallTool(
+      name: string,
+      args: Record<string, unknown>,
+      context: McpCallToolContext
+    ): Promise<McpCallToolOutcome>
+
     mcpAddResource<TUriSchema extends TSchema = TString>(
       definition: Omit<Resource, 'uri'> & {
         uriPattern: string,
@@ -195,6 +201,18 @@ export type MCPRouteSchemaTransformer = (
   schema: FastifySchema,
   context: MCPRouteSchemaContext
 ) => FastifySchema
+
+export interface McpCallToolContext {
+  request: FastifyRequest
+  reply: FastifyReply
+  authContext?: AuthorizationContext
+}
+
+export type McpCallToolOutcome =
+  | { ok: true, result: CallToolResult }
+  | { ok: false, reason: 'not-found' }
+  | { ok: false, reason: 'invalid-arguments', detail: string }
+  | { ok: false, reason: 'task-required' }
 
 export interface MCPPluginOptions {
   serverInfo?: Implementation

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -5,7 +5,7 @@ import {
   expectNotAssignable,
 } from 'tsd'
 import { Type } from '@sinclair/typebox'
-import type { FastifyReply, FastifyRequest, FastifySchema, HTTPMethods } from 'fastify'
+import type { FastifyInstance, FastifyReply, FastifyRequest, FastifySchema, HTTPMethods } from 'fastify'
 import { RedisMessageBroker, MemoryMessageBroker, RedisSessionStore, MemorySessionStore } from '../dist/index.js'
 import type {
   ToolHandler,
@@ -30,6 +30,8 @@ import type {
   MCPRouteId,
   MCPRouteSchemaContext,
   MCPRouteSchemaTransformer,
+  McpCallToolContext,
+  McpCallToolOutcome,
 } from '../dist/index.js'
 
 // ─── ToolHandler ─────────────────────────────────────────────────────
@@ -364,6 +366,30 @@ expectAssignable<MCPPluginOptions>({ canAccessTool: accessHook })
 // The context type is exported and carries a required request
 expectAssignable<ToolAccessContext>({ request: {} as FastifyRequest })
 expectNotAssignable<ToolAccessContext>({})
+
+// mcpCallTool is decorated on Fastify and returns the exported outcome union
+const fastifyApp = {} as FastifyInstance
+expectType<Promise<McpCallToolOutcome>>(
+  fastifyApp.mcpCallTool('echo', {}, { request: {} as FastifyRequest, reply: {} as FastifyReply })
+)
+expectAssignable<McpCallToolContext>({
+  request: {} as FastifyRequest,
+  reply: {} as FastifyReply
+})
+expectAssignable<McpCallToolContext>({
+  request: {} as FastifyRequest,
+  reply: {} as FastifyReply,
+  authContext: { userId: 'user-123', tokenType: 'Bearer' }
+})
+expectNotAssignable<McpCallToolContext>({ request: {} as FastifyRequest })
+expectNotAssignable<McpCallToolContext>({})
+expectAssignable<McpCallToolOutcome>({ ok: true, result: { content: [{ type: 'text', text: 'ok' }] } })
+expectAssignable<McpCallToolOutcome>({ ok: false, reason: 'not-found' })
+expectNotAssignable<McpCallToolOutcome>({ ok: false, reason: 'unknown-tool' })
+expectNotAssignable<McpCallToolOutcome>({ ok: false, reason: 'access-denied' })
+expectAssignable<McpCallToolOutcome>({ ok: false, reason: 'invalid-arguments', detail: 'missing input' })
+expectAssignable<McpCallToolOutcome>({ ok: false, reason: 'task-required' })
+expectNotAssignable<McpCallToolOutcome>({ ok: false, reason: 'nope' })
 
 // Sync and async hooks are both accepted
 expectAssignable<MCPPluginOptions>({ canAccessTool: () => true })

--- a/test/mcp-call-tool.test.ts
+++ b/test/mcp-call-tool.test.ts
@@ -1,0 +1,502 @@
+import { test, describe } from 'node:test'
+import type { TestContext } from 'node:test'
+import Fastify from 'fastify'
+import type { FastifyRequest } from 'fastify'
+import { Type } from '@sinclair/typebox'
+import mcpPlugin from '../src/index.ts'
+import type { JSONRPCErrorResponse, JSONRPCRequest, JSONRPCResultResponse, CallToolResult } from '../src/index.ts'
+import { JSONRPC_VERSION, LATEST_PROTOCOL_VERSION, METHOD_NOT_FOUND } from '../src/schema.ts'
+
+type DirectBody = {
+  name: string
+  args?: Record<string, unknown>
+  authUserId?: string
+  authScopes?: string[]
+  spoofContextOverrides?: boolean
+}
+
+const SEARCH_JSON_SCHEMA = {
+  type: 'object' as const,
+  properties: {
+    query: { type: 'string', minLength: 1 }
+  },
+  required: ['query'],
+  additionalProperties: false
+}
+
+async function buildApp (t: TestContext) {
+  let handlerInvocations = 0
+  let taskOnlyInvocations = 0
+  let jsonSchemaInvocations = 0
+  let accessContextRequest: FastifyRequest | undefined
+  let directRouteRequest: FastifyRequest | undefined
+
+  const app = Fastify({ logger: false })
+  t.after(() => app.close())
+
+  await app.register(mcpPlugin, {
+    enableSSE: true,
+    validateJsonSchemaInputs: {},
+    canAccessTool: (toolName, context) => {
+      accessContextRequest = context.request
+      if (toolName === 'wallet-summary') {
+        return context.authContext?.scopes?.includes('wallet-summary:read') === true
+      }
+      return toolName !== 'restricted'
+    }
+  })
+
+  app.mcpAddTool({
+    name: 'echo',
+    description: 'Echo a message',
+    inputSchema: Type.Object({
+      message: Type.String()
+    })
+  }, async (args) => {
+    handlerInvocations++
+    return { content: [{ type: 'text', text: args.message }] }
+  })
+
+  app.mcpAddTool({
+    name: 'restricted',
+    description: 'Denied by canAccessTool',
+    inputSchema: Type.Object({})
+  }, async () => {
+    handlerInvocations++
+    return { content: [{ type: 'text', text: 'restricted ok' }] }
+  })
+
+  app.mcpAddTool({
+    name: 'throws',
+    description: 'Throws from handler',
+    inputSchema: Type.Object({})
+  }, async () => {
+    throw new Error('kaboom')
+  })
+
+  app.mcpAddTool({
+    name: 'missing-handler',
+    description: 'Registered without a handler',
+    inputSchema: Type.Object({})
+  })
+
+  app.mcpAddTool({
+    name: 'json-search',
+    description: 'Plain JSON Schema search',
+    inputSchema: SEARCH_JSON_SCHEMA
+  }, async () => {
+    jsonSchemaInvocations++
+    return { content: [{ type: 'text', text: 'json ok' }] }
+  })
+
+  app.mcpAddTool({
+    name: 'session-id',
+    description: 'Returns the active session id',
+    inputSchema: Type.Object({})
+  }, async (_args, context) => {
+    return { content: [{ type: 'text', text: context.sessionId ?? 'missing' }] }
+  })
+
+  app.mcpAddTool({
+    name: 'reply-aware',
+    description: 'Touches the Fastify reply',
+    inputSchema: Type.Object({})
+  }, async (_args, context) => {
+    context.reply.header('x-tool-reply', 'applied')
+    context.reply.code(209)
+    return { content: [{ type: 'text', text: 'reply ok' }] }
+  })
+
+  app.mcpAddTool({
+    name: 'task-only',
+    description: 'Requires task execution',
+    inputSchema: Type.Object({}),
+    execution: { taskSupport: 'required' }
+  }, async () => {
+    taskOnlyInvocations++
+    return { content: [{ type: 'text', text: 'task ok' }] }
+  })
+
+  app.mcpAddTool({
+    name: 'auth-context',
+    description: 'Returns auth context user id',
+    inputSchema: Type.Object({})
+  }, async (_args, context) => {
+    return { content: [{ type: 'text', text: context.authContext?.userId ?? 'missing' }] }
+  })
+
+  app.mcpAddTool({
+    name: 'wallet-summary',
+    description: 'Returns a wallet summary',
+    inputSchema: Type.Object({})
+  }, async () => {
+    return { content: [{ type: 'text', text: 'wallet ok' }] }
+  })
+
+  app.post('/direct-tool-call', async (request, reply) => {
+    directRouteRequest = request
+    const body = request.body as DirectBody
+    if (body.spoofContextOverrides === true) {
+      // Simulate a JS/any caller injecting undeclared properties on context.
+      const contextWithOverrides = {
+        request,
+        reply,
+        opts: {
+          canAccessTool: () => true
+        },
+        tools: new Map([
+          ['echo', {
+            definition: {
+              name: 'echo',
+              description: 'Spoofed echo',
+              inputSchema: Type.Object({ message: Type.String() })
+            },
+            handler: async () => ({ content: [{ type: 'text', text: 'spoofed' }] })
+          }]
+        ])
+      } as unknown as Parameters<typeof app.mcpCallTool>[2]
+
+      return await app.mcpCallTool(body.name, body.args ?? {}, contextWithOverrides)
+    }
+
+    if (body.authUserId !== undefined || body.authScopes !== undefined) {
+      return await app.mcpCallTool(body.name, body.args ?? {}, {
+        request,
+        reply,
+        authContext: { userId: body.authUserId, scopes: body.authScopes, tokenType: 'Bearer' }
+      })
+    }
+    return await app.mcpCallTool(body.name, body.args ?? {}, { request, reply })
+  })
+
+  await app.ready()
+
+  return {
+    app,
+    getHandlerInvocations: () => handlerInvocations,
+    getJsonSchemaInvocations: () => jsonSchemaInvocations,
+    getTaskOnlyInvocations: () => taskOnlyInvocations,
+    getAccessContextRequest: () => accessContextRequest,
+    getDirectRouteRequest: () => directRouteRequest
+  }
+}
+
+function callRequest (name: string, args: Record<string, unknown>, id = 1): JSONRPCRequest {
+  return {
+    jsonrpc: JSONRPC_VERSION,
+    id,
+    method: 'tools/call',
+    params: { name, arguments: args }
+  }
+}
+
+function initializeRequest (id = 100): JSONRPCRequest {
+  return {
+    jsonrpc: JSONRPC_VERSION,
+    id,
+    method: 'initialize',
+    params: {
+      protocolVersion: LATEST_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: 'test-client', version: '1.0.0' }
+    }
+  }
+}
+
+function textFromResult (result: CallToolResult): string {
+  const content = result.content[0]
+  tAssertTextContent(content)
+  return content.text
+}
+
+function tAssertTextContent (content: CallToolResult['content'][number]): asserts content is { type: 'text', text: string } {
+  if (content.type !== 'text') {
+    throw new Error(`Expected text content, got ${content.type}`)
+  }
+}
+
+describe('mcpCallTool', () => {
+  test('returns a successful tool result in-process', async (t: TestContext) => {
+    const { app } = await buildApp(t)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'echo', args: { message: 'hello' } }
+    })
+
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.deepStrictEqual(response.json(), {
+      ok: true,
+      result: { content: [{ type: 'text', text: 'hello' }] }
+    })
+  })
+
+  test('reports unknown and denied tools without invoking handlers', async (t: TestContext) => {
+    const { app, getHandlerInvocations } = await buildApp(t)
+
+    const unknownResponse = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'missing', args: {} }
+    })
+    const deniedResponse = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'restricted', args: {} }
+    })
+
+    t.assert.deepStrictEqual(unknownResponse.json(), { ok: false, reason: 'not-found' })
+    t.assert.deepStrictEqual(deniedResponse.json(), { ok: false, reason: 'not-found' })
+    t.assert.strictEqual(getHandlerInvocations(), 0)
+  })
+
+  test('reports invalid arguments without invoking the handler', async (t: TestContext) => {
+    const { app, getHandlerInvocations } = await buildApp(t)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'echo', args: {} }
+    })
+    const body = response.json() as { ok: false, reason: string, detail: string }
+
+    t.assert.strictEqual(body.ok, false)
+    t.assert.strictEqual(body.reason, 'invalid-arguments')
+    t.assert.ok(body.detail.length > 0)
+    t.assert.strictEqual(getHandlerInvocations(), 0)
+  })
+
+  test('passes the same request object to canAccessTool', async (t: TestContext) => {
+    const { app, getAccessContextRequest, getDirectRouteRequest } = await buildApp(t)
+
+    await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'echo', args: { message: 'hello' } }
+    })
+
+    t.assert.strictEqual(getAccessContextRequest(), getDirectRouteRequest())
+  })
+
+  test('matches the JSON-RPC tools/call path for success and failure outcomes', async (t: TestContext) => {
+    const { app } = await buildApp(t)
+
+    const directOk = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'echo', args: { message: 'hello' } }
+    })
+    const rpcOk = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: callRequest('echo', { message: 'hello' }, 1)
+    })
+    t.assert.deepStrictEqual((directOk.json() as { result: CallToolResult }).result, (rpcOk.json() as JSONRPCResultResponse).result)
+
+    const directUnknown = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'missing', args: {} }
+    })
+    const rpcUnknown = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: callRequest('missing', {}, 2)
+    })
+    t.assert.deepStrictEqual(directUnknown.json(), { ok: false, reason: 'not-found' })
+    const unknownError = (rpcUnknown.json() as JSONRPCErrorResponse).error
+    t.assert.strictEqual(unknownError.code, METHOD_NOT_FOUND)
+    t.assert.strictEqual(unknownError.message, "Tool 'missing' not found")
+
+    const directDenied = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'restricted', args: {} }
+    })
+    const rpcDenied = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: callRequest('restricted', {}, 3)
+    })
+    t.assert.deepStrictEqual(directDenied.json(), { ok: false, reason: 'not-found' })
+    const deniedError = (rpcDenied.json() as JSONRPCErrorResponse).error
+    t.assert.strictEqual(deniedError.code, METHOD_NOT_FOUND)
+    t.assert.strictEqual(deniedError.message, "Tool 'restricted' not found")
+
+    const directInvalid = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'echo', args: {} }
+    })
+    const rpcInvalid = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: callRequest('echo', {}, 4)
+    })
+    const invalidOutcome = directInvalid.json() as { ok: false, reason: string, detail: string }
+    const invalidResult = (rpcInvalid.json() as JSONRPCResultResponse).result as CallToolResult
+    t.assert.strictEqual(invalidOutcome.reason, 'invalid-arguments')
+    t.assert.deepStrictEqual(invalidResult, {
+      content: [{ type: 'text', text: `Invalid tool arguments: ${invalidOutcome.detail}` }],
+      isError: true
+    })
+  })
+
+  test('converts thrown handler errors to isError results matching JSON-RPC', async (t: TestContext) => {
+    const { app } = await buildApp(t)
+
+    const directResponse = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'throws', args: {} }
+    })
+    const rpcResponse = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: callRequest('throws', {}, 5)
+    })
+
+    const directBody = directResponse.json() as { ok: true, result: CallToolResult }
+    const rpcBody = rpcResponse.json() as JSONRPCResultResponse
+    t.assert.strictEqual(directBody.ok, true)
+    t.assert.strictEqual(directBody.result.isError, true)
+    t.assert.deepStrictEqual(directBody.result, rpcBody.result)
+    t.assert.match(textFromResult(directBody.result), /kaboom/)
+  })
+
+  test('returns an isError result for tools registered without a handler', async (t: TestContext) => {
+    const { app } = await buildApp(t)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'missing-handler', args: {} }
+    })
+    const body = response.json() as { ok: true, result: CallToolResult }
+
+    t.assert.strictEqual(body.ok, true)
+    t.assert.strictEqual(body.result.isError, true)
+    t.assert.match(textFromResult(body.result), /no handler implementation/)
+  })
+
+  test('reports invalid arguments from the AJV JSON Schema branch', async (t: TestContext) => {
+    const { app, getJsonSchemaInvocations } = await buildApp(t)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'json-search', args: { query: '' } }
+    })
+    const body = response.json() as { ok: false, reason: string, detail: string }
+
+    t.assert.strictEqual(body.ok, false)
+    t.assert.strictEqual(body.reason, 'invalid-arguments')
+    t.assert.match(body.detail, /query/)
+    t.assert.strictEqual(getJsonSchemaInvocations(), 0)
+  })
+
+  test('passes the active session id to the non-task JSON-RPC tools/call path', async (t: TestContext) => {
+    const { app } = await buildApp(t)
+
+    const init = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      payload: initializeRequest()
+    })
+    const sessionId = init.headers['mcp-session-id'] as string | undefined
+    t.assert.ok(sessionId)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/mcp',
+      headers: { 'mcp-session-id': sessionId },
+      payload: callRequest('session-id', {}, 6)
+    })
+    const result = (response.json() as JSONRPCResultResponse).result as CallToolResult
+
+    t.assert.strictEqual(textFromResult(result), sessionId)
+  })
+
+  test('passes the route FastifyReply to handlers invoked in-process', async (t: TestContext) => {
+    const { app } = await buildApp(t)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'reply-aware', args: {} }
+    })
+
+    t.assert.strictEqual(response.statusCode, 209)
+    t.assert.strictEqual(response.headers['x-tool-reply'], 'applied')
+    t.assert.strictEqual(textFromResult((response.json() as { ok: true, result: CallToolResult }).result), 'reply ok')
+  })
+
+  test('does not execute task-required tools in-process', async (t: TestContext) => {
+    const { app, getTaskOnlyInvocations } = await buildApp(t)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'task-only', args: {} }
+    })
+
+    t.assert.deepStrictEqual(response.json(), { ok: false, reason: 'task-required' })
+    t.assert.strictEqual(getTaskOnlyInvocations(), 0)
+  })
+
+  test('passes caller-provided authContext to in-process handlers', async (t: TestContext) => {
+    const { app } = await buildApp(t)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'auth-context', args: {}, authUserId: 'user-123' }
+    })
+    const body = response.json() as { ok: true, result: CallToolResult }
+
+    t.assert.strictEqual(textFromResult(body.result), 'user-123')
+  })
+
+  test('passes caller-provided authContext scopes to canAccessTool', async (t: TestContext) => {
+    const { app } = await buildApp(t)
+
+    const deniedResponse = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'wallet-summary', args: {}, authScopes: ['profile:read'] }
+    })
+    t.assert.deepStrictEqual(deniedResponse.json(), { ok: false, reason: 'not-found' })
+
+    const allowedResponse = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'wallet-summary', args: {}, authScopes: ['wallet-summary:read'] }
+    })
+    const body = allowedResponse.json() as { ok: true, result: CallToolResult }
+
+    t.assert.strictEqual(body.ok, true)
+    t.assert.strictEqual(textFromResult(body.result), 'wallet ok')
+  })
+
+  test('ignores casted context opts/tools overrides for in-process calls', async (t: TestContext) => {
+    const { app } = await buildApp(t)
+
+    const deniedResponse = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'restricted', args: {}, spoofContextOverrides: true }
+    })
+    t.assert.deepStrictEqual(deniedResponse.json(), { ok: false, reason: 'not-found' })
+
+    const allowedResponse = await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'echo', args: { message: 'hello' }, spoofContextOverrides: true }
+    })
+    t.assert.deepStrictEqual(allowedResponse.json(), {
+      ok: true,
+      result: { content: [{ type: 'text', text: 'hello' }] }
+    })
+  })
+})


### PR DESCRIPTION
Add app.mcpCallTool() so server code can invoke registered MCP tools without a loopback HTTP request.