### PR TITLE
feat(tools): add read only tool registry introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,6 +1854,51 @@ app.mcpAddPrompt(
 )
 ```
 
+#### Server-Side Tool Registry Introspection
+
+Use these decorators to introspect tool registration state from server-side code:
+
+- `app.mcpHasTool(name: string): boolean`
+- `app.mcpListToolNames(): readonly string[]`
+
+Important behavior:
+
+- Available only within the MCP plugin Fastify encapsulation scope (the registration scope and descendants)
+- Reports registration state, not request-specific visibility
+- Does not evaluate `canAccessTool`
+- Returns a read-only snapshot of names in registration order
+
+Because this API is authorization-agnostic by design, avoid exposing it directly to untrusted clients unless you enforce your own authorization.
+
+```typescript
+await app.register(mcpPlugin)
+
+app.mcpAddTool({
+  name: 'search',
+  description: 'Search documents',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: { type: 'string' }
+    },
+    required: ['query']
+  }
+}, async ({ query }) => {
+  return {
+    content: [{ type: 'text', text: `Searching for ${query}` }]
+  }
+})
+
+app.get('/internal/tool-status', async () => {
+  return {
+    searchRegistered: app.mcpHasTool('search'),
+    registeredTools: app.mcpListToolNames()
+  }
+})
+```
+
+This route is illustrative only and should be protected in real deployments.
+
 #### HTTP Context Access in Tool Handlers
 
 Tool handlers can access the Fastify request and reply objects through the context parameter, enabling tools to interact with HTTP-specific features like headers, query parameters, and custom response headers. 

--- a/src/decorators/meta.ts
+++ b/src/decorators/meta.ts
@@ -79,6 +79,14 @@ const mcpDecoratorsPlugin: FastifyPluginAsync<MCPDecoratorsOptions> = async (app
     })
   })
 
+  app.decorate('mcpHasTool', (name: string): boolean => {
+    return tools.has(name)
+  })
+
+  app.decorate('mcpListToolNames', (): readonly string[] => {
+    return [...tools.keys()]
+  })
+
   // Enhanced resource decorator with URI schema support
   app.decorate('mcpAddResource', (
     definition: any,

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,8 @@ declare module 'fastify' {
       args: Record<string, unknown>,
       context: McpCallToolContext
     ): Promise<McpCallToolOutcome>
+    mcpHasTool(name: string): boolean
+    mcpListToolNames(): readonly string[]
 
     mcpAddResource<TUriSchema extends TSchema = TString>(
       definition: Omit<Resource, 'uri'> & {

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -424,3 +424,11 @@ expectNotAssignable<MCPPluginOptions>({
 expectNotAssignable<MCPPluginOptions>({
   validateJsonSchemaInputs: 'yes'
 })
+
+// ─── Fastify decorators ─────────────────────────────────────────────
+
+const app = {} as FastifyInstance
+
+expectType<boolean>(app.mcpHasTool('search'))
+expectType<readonly string[]>(app.mcpListToolNames())
+expectError(app.mcpListToolNames().push('search'))

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -651,6 +651,92 @@ describe('MCP Fastify Plugin', () => {
       t.assert.strictEqual(result.prompts.length, 1)
       t.assert.strictEqual(result.prompts[0].name, 'test-prompt')
     })
+
+    test('should provide mcpHasTool and mcpListToolNames decorators', async (t: TestContext) => {
+      const app = Fastify()
+      t.after(() => app.close())
+
+      await app.register(mcpPlugin)
+      await app.ready()
+
+      t.assert.ok(typeof app.mcpHasTool === 'function')
+      t.assert.ok(typeof app.mcpListToolNames === 'function')
+    })
+
+    test('mcpHasTool should report registered and unknown tools', async (t: TestContext) => {
+      const app = Fastify()
+      t.after(() => app.close())
+
+      await app.register(mcpPlugin)
+      await app.ready()
+
+      app.mcpAddTool({
+        name: 'search',
+        description: 'Search tool',
+        inputSchema: { type: 'object', properties: {} }
+      })
+
+      t.assert.strictEqual(app.mcpHasTool('search'), true)
+      t.assert.strictEqual(app.mcpHasTool('unknown'), false)
+    })
+
+    test('mcpListToolNames should return all names in registration order', async (t: TestContext) => {
+      const app = Fastify()
+      t.after(() => app.close())
+
+      await app.register(mcpPlugin)
+      await app.ready()
+
+      app.mcpAddTool({ name: 'search', description: 'Search', inputSchema: { type: 'object', properties: {} } })
+      app.mcpAddTool({ name: 'summarize', description: 'Summarize', inputSchema: { type: 'object', properties: {} } })
+      app.mcpAddTool({ name: 'translate', description: 'Translate', inputSchema: { type: 'object', properties: {} } })
+
+      t.assert.deepStrictEqual(app.mcpListToolNames(), ['search', 'summarize', 'translate'])
+    })
+
+    test('mcpListToolNames should reflect tools added after an earlier call', async (t: TestContext) => {
+      const app = Fastify()
+      t.after(() => app.close())
+
+      await app.register(mcpPlugin)
+      await app.ready()
+
+      app.mcpAddTool({ name: 'search', description: 'Search', inputSchema: { type: 'object', properties: {} } })
+      t.assert.deepStrictEqual(app.mcpListToolNames(), ['search'])
+
+      app.mcpAddTool({ name: 'summarize', description: 'Summarize', inputSchema: { type: 'object', properties: {} } })
+      t.assert.deepStrictEqual(app.mcpListToolNames(), ['search', 'summarize'])
+    })
+
+    test('tool registry introspection should not invoke handlers or canAccessTool', async (t: TestContext) => {
+      let handlerCallCount = 0
+      let canAccessCallCount = 0
+
+      const app = Fastify()
+      t.after(() => app.close())
+
+      await app.register(mcpPlugin, {
+        canAccessTool: async () => {
+          canAccessCallCount++
+          return false
+        }
+      })
+      await app.ready()
+
+      app.mcpAddTool({
+        name: 'denied-tool',
+        description: 'Denied tool',
+        inputSchema: { type: 'object', properties: {} }
+      }, async () => {
+        handlerCallCount++
+        return { content: [{ type: 'text', text: 'ok' }] }
+      })
+
+      t.assert.strictEqual(app.mcpHasTool('denied-tool'), true)
+      t.assert.deepStrictEqual(app.mcpListToolNames(), ['denied-tool'])
+      t.assert.strictEqual(handlerCallCount, 0)
+      t.assert.strictEqual(canAccessCallCount, 0)
+    })
   })
 
   describe('Top-Level Exports', () => {


### PR DESCRIPTION
provide 2 new fastify decorators to introspect tool registration state from server-side code:
1. `mcpHasTool`
2. `mcpListToolNames`