### PR TITLE
feat(routes): add MCP route schema transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,6 +1484,52 @@ The hook receives the tool name and a per-request context (`authContext`, `reque
 
 A hook that throws denies access (fail closed) and logs a warning. Only an explicit `true` grants access. Without the hook, every registered tool stays visible and callable.
 
+## Customizing MCP Route Schemas
+
+Use `transformRouteSchema` to customize Fastify/OpenAPI schema metadata on MCP transport routes without replacing handlers or route definitions.
+
+```typescript
+import Fastify from 'fastify'
+import mcpPlugin from '@platformatic/mcp'
+
+const app = Fastify()
+
+await app.register(mcpPlugin, {
+  transformRouteSchema (schema, { routeId }) {
+    return {
+      ...schema,
+      tags: ['MCP'],
+      security: [{ oauth2: ['tools:read'] }],
+      operationId: routeId.replace('.', '-'),
+      'x-roles': ['admin']
+    }
+  }
+})
+```
+
+Route IDs are stable and map to MCP transport routes:
+
+| Route ID | Method | Purpose |
+|---|---|---|
+| `mcp.post` | `POST` | MCP JSON-RPC messages |
+| `mcp.get` | `GET` | MCP streaming/SSE connection |
+| `mcp.delete` | `DELETE` | MCP session termination |
+
+Behavior notes:
+
+- The callback runs once per registered MCP transport route during startup.
+- The plugin passes the original route schema object to the callback.
+- Spread the incoming schema when you want to preserve existing fields.
+- The callback is synchronous and must return a schema object.
+- Returned metadata applies only to Fastify/OpenAPI schema fields.
+- OAuth and well-known routes are not customized by this option in this version.
+
+Security notes:
+
+- OpenAPI schema metadata does not enforce authentication or authorization.
+- For example, `security: [{ oauth2: ['tools:read'] }]` documents expectations but does not install auth checks.
+- Enforcement still depends on your configured auth hooks, token validation, and tool access controls.
+
 ### OAuth Routes
 
 The plugin automatically registers OAuth management routes:

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,6 +257,9 @@ export type {
 // Export plugin types
 export type {
   MCPPluginOptions,
+  MCPRouteId,
+  MCPRouteSchemaContext,
+  MCPRouteSchemaTransformer,
   ToolAccessContext,
   MCPTool,
   MCPResource,

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -1,10 +1,18 @@
 import { randomUUID } from 'crypto'
-import type { FastifyRequest, FastifyReply, FastifyPluginAsync } from 'fastify'
+import type { FastifyRequest, FastifyReply, FastifyPluginAsync, FastifySchema } from 'fastify'
 import fp from 'fastify-plugin'
 import type { JSONRPCMessage } from '../schema.ts'
 import { JSONRPC_VERSION, INTERNAL_ERROR, SUPPORTED_PROTOCOL_VERSIONS, DEFAULT_NEGOTIATED_PROTOCOL_VERSION } from '../schema.ts'
 import { isOriginAllowed } from '../security.ts'
-import type { MCPPluginOptions, MCPTool, MCPResource, MCPPrompt, ResourceHandlers } from '../types.ts'
+import type {
+  MCPPluginOptions,
+  MCPTool,
+  MCPResource,
+  MCPPrompt,
+  ResourceHandlers,
+  MCPRouteSchemaContext,
+  MCPRouteSchemaTransformer
+} from '../types.ts'
 import type { SessionStore, SessionMetadata } from '../stores/session-store.ts'
 import type { TaskStore, TaskWaiters } from '../stores/task-store.ts'
 import type { MessageBroker } from '../brokers/message-broker.ts'
@@ -29,8 +37,46 @@ interface MCPPubSubRoutesOptions {
   jsonSchemaValidator?: JsonSchemaValidator
 }
 
+function resolveRouteUrl (prefix: string | undefined, url: string): string {
+  if (!prefix || prefix === '/') {
+    return url
+  }
+
+  const normalizedPrefix = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
+  return `${normalizedPrefix}${url}`
+}
+
+function isThenable (value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  )
+}
+
+function resolveMcpRouteSchema (
+  defaultSchema: FastifySchema | undefined,
+  context: MCPRouteSchemaContext,
+  transform?: MCPRouteSchemaTransformer
+): FastifySchema | undefined {
+  if (!transform) {
+    return defaultSchema
+  }
+
+  const schema = defaultSchema ?? {}
+  const transformed = transform(schema, context)
+
+  if (typeof transformed !== 'object' || transformed === null || Array.isArray(transformed) || isThenable(transformed)) {
+    throw new TypeError(`transformRouteSchema must return a synchronous Fastify schema object for ${context.routeId}`)
+  }
+
+  return transformed
+}
+
 const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async (app, options) => {
   const { enableSSE, opts, capabilities, serverInfo, tools, resources, prompts, resourceHandlers, sessionStore, messageBroker, localStreams, taskStore, taskWaiters, jsonSchemaValidator } = options
+  const mcpUrl = resolveRouteUrl(app.prefix, '/mcp')
 
   const allowedOrigins = opts.allowedOrigins
 
@@ -226,12 +272,146 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
     }
   }
 
-  app.post('/mcp', { onRequest: mcpOnRequest, preHandler: mcpPreHandler }, async (request: FastifyRequest, reply: FastifyReply) => {
-    try {
-      const message = request.body as JSONRPCMessage
-      let sessionId = request.headers['mcp-session-id'] as string
+  {
+    const schema = resolveMcpRouteSchema(undefined, {
+      routeId: 'mcp.post',
+      method: 'POST',
+      url: mcpUrl
+    }, opts.transformRouteSchema)
+    const routeOptions = schema === undefined
+      ? { onRequest: mcpOnRequest, preHandler: mcpPreHandler }
+      : { onRequest: mcpOnRequest, preHandler: mcpPreHandler, schema }
 
-      if (enableSSE) {
+    app.post('/mcp', routeOptions, async (request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        const message = request.body as JSONRPCMessage
+        let sessionId = request.headers['mcp-session-id'] as string
+
+        if (enableSSE) {
+          let session: SessionMetadata
+          if (sessionId) {
+            const existingSession = await sessionStore.get(sessionId)
+            if (existingSession) {
+              session = existingSession
+            } else {
+              session = await createSSESession()
+              reply.header('Mcp-Session-Id', session.id)
+            }
+          } else {
+            session = await createSSESession()
+            reply.header('Mcp-Session-Id', session.id)
+          }
+          sessionId = session.id
+        }
+
+        // Build auth context from validated token payload
+        let authContext: AuthorizationContext | undefined
+        if ((request as any).tokenPayload) {
+          const payload = (request as any).tokenPayload
+          authContext = {
+            userId: payload.sub,
+            clientId: payload.client_id || payload.azp,
+            scopes: typeof payload.scope === 'string'
+              ? payload.scope.split(' ')
+              : payload.scopes,
+            audience: Array.isArray(payload.aud)
+              ? payload.aud
+              : payload.aud ? [payload.aud] : undefined,
+            tokenType: 'Bearer',
+            expiresAt: payload.exp ? new Date(payload.exp * 1000) : undefined,
+            issuedAt: payload.iat ? new Date(payload.iat * 1000) : undefined,
+            authorizationServer: payload.iss
+          }
+        } else if (sessionId) {
+        // Fallback to session-stored auth context
+          const session = await sessionStore.get(sessionId)
+          authContext = session?.authorization
+        }
+
+        const response = await processMessage(message, sessionId, {
+          app,
+          opts,
+          capabilities,
+          serverInfo,
+          tools,
+          resources,
+          prompts,
+          resourceHandlers,
+          request,
+          reply,
+          authContext,
+          sessionStore,
+          taskStore,
+          taskWaiters,
+          jsonSchemaValidator,
+          sessionId,
+          protocolVersion: (request as any).mcpProtocolVersion ?? DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+        })
+        if (response) {
+          return response
+        } else {
+          reply.code(202)
+        }
+      } catch (error) {
+        app.log.error({ err: error }, 'Error processing MCP message')
+        reply.type('application/json').code(500).send({
+          jsonrpc: JSONRPC_VERSION,
+          id: null,
+          error: {
+            code: INTERNAL_ERROR,
+            message: 'Internal server error'
+          }
+        })
+      }
+    })
+  }
+
+  // GET endpoint for server-initiated communication via SSE
+  if (!enableSSE) {
+    app.get('/mcp', { onRequest: mcpOnRequest, preHandler: mcpPreHandler }, async (_request: FastifyRequest, reply: FastifyReply) => {
+      reply.type('application/json').code(405).send({ error: 'Method Not Allowed: SSE not enabled' })
+    })
+  }
+
+  if (enableSSE) {
+    const schema = resolveMcpRouteSchema(undefined, {
+      routeId: 'mcp.get',
+      method: 'GET',
+      url: mcpUrl
+    }, opts.transformRouteSchema)
+    const routeOptions = schema === undefined
+      ? { onRequest: mcpOnRequest, preHandler: mcpPreHandler }
+      : { onRequest: mcpOnRequest, preHandler: mcpPreHandler, schema }
+
+    app.get('/mcp', routeOptions, async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!supportsSSE(request)) {
+        reply.type('application/json').code(405).send({ error: 'Method Not Allowed: SSE not supported' })
+        return
+      }
+
+      try {
+        const sessionId = (request.headers['mcp-session-id'] as string) ||
+                       (request.query as any)['mcp-session-id']
+
+        // Check if there's already an active SSE session
+        if (hasActiveSSESession(sessionId)) {
+          reply.type('application/json').code(409).send({
+            error: 'Conflict: SSE session already active for this session ID'
+          })
+          return
+        }
+
+        request.log.info({ sessionId }, 'Handling SSE request')
+
+        // We are opting out of Fastify proper
+        reply.hijack()
+
+        const raw = reply.raw
+
+        // Set up SSE stream
+        raw.setHeader('Content-type', 'text/event-stream')
+        raw.setHeader('Cache-Control', 'no-cache')
+
         let session: SessionMetadata
         if (sessionId) {
           const existingSession = await sessionStore.get(sessionId)
@@ -239,220 +419,118 @@ const mcpPubSubRoutesPlugin: FastifyPluginAsync<MCPPubSubRoutesOptions> = async 
             session = existingSession
           } else {
             session = await createSSESession()
-            reply.header('Mcp-Session-Id', session.id)
+            raw.setHeader('Mcp-Session-Id', session.id)
           }
-        } else {
-          session = await createSSESession()
-          reply.header('Mcp-Session-Id', session.id)
-        }
-        sessionId = session.id
-      }
-
-      // Build auth context from validated token payload
-      let authContext: AuthorizationContext | undefined
-      if ((request as any).tokenPayload) {
-        const payload = (request as any).tokenPayload
-        authContext = {
-          userId: payload.sub,
-          clientId: payload.client_id || payload.azp,
-          scopes: typeof payload.scope === 'string'
-            ? payload.scope.split(' ')
-            : payload.scopes,
-          audience: Array.isArray(payload.aud)
-            ? payload.aud
-            : payload.aud ? [payload.aud] : undefined,
-          tokenType: 'Bearer',
-          expiresAt: payload.exp ? new Date(payload.exp * 1000) : undefined,
-          issuedAt: payload.iat ? new Date(payload.iat * 1000) : undefined,
-          authorizationServer: payload.iss
-        }
-      } else if (sessionId) {
-        // Fallback to session-stored auth context
-        const session = await sessionStore.get(sessionId)
-        authContext = session?.authorization
-      }
-
-      const response = await processMessage(message, sessionId, {
-        app,
-        opts,
-        capabilities,
-        serverInfo,
-        tools,
-        resources,
-        prompts,
-        resourceHandlers,
-        request,
-        reply,
-        authContext,
-        sessionStore,
-        taskStore,
-        taskWaiters,
-        jsonSchemaValidator,
-        sessionId,
-        protocolVersion: (request as any).mcpProtocolVersion ?? DEFAULT_NEGOTIATED_PROTOCOL_VERSION
-      })
-      if (response) {
-        return response
-      } else {
-        reply.code(202)
-      }
-    } catch (error) {
-      app.log.error({ err: error }, 'Error processing MCP message')
-      reply.type('application/json').code(500).send({
-        jsonrpc: JSONRPC_VERSION,
-        id: null,
-        error: {
-          code: INTERNAL_ERROR,
-          message: 'Internal server error'
-        }
-      })
-    }
-  })
-
-  // GET endpoint for server-initiated communication via SSE
-  app.get('/mcp', { onRequest: mcpOnRequest, preHandler: mcpPreHandler }, async (request: FastifyRequest, reply: FastifyReply) => {
-    if (!enableSSE) {
-      reply.type('application/json').code(405).send({ error: 'Method Not Allowed: SSE not enabled' })
-      return
-    }
-
-    if (!supportsSSE(request)) {
-      reply.type('application/json').code(405).send({ error: 'Method Not Allowed: SSE not supported' })
-      return
-    }
-
-    try {
-      const sessionId = (request.headers['mcp-session-id'] as string) ||
-                       (request.query as any)['mcp-session-id']
-
-      // Check if there's already an active SSE session
-      if (hasActiveSSESession(sessionId)) {
-        reply.type('application/json').code(409).send({
-          error: 'Conflict: SSE session already active for this session ID'
-        })
-        return
-      }
-
-      request.log.info({ sessionId }, 'Handling SSE request')
-
-      // We are opting out of Fastify proper
-      reply.hijack()
-
-      const raw = reply.raw
-
-      // Set up SSE stream
-      raw.setHeader('Content-type', 'text/event-stream')
-      raw.setHeader('Cache-Control', 'no-cache')
-
-      let session: SessionMetadata
-      if (sessionId) {
-        const existingSession = await sessionStore.get(sessionId)
-        if (existingSession) {
-          session = existingSession
         } else {
           session = await createSSESession()
           raw.setHeader('Mcp-Session-Id', session.id)
         }
-      } else {
-        session = await createSSESession()
-        raw.setHeader('Mcp-Session-Id', session.id)
-      }
 
-      raw.writeHead(200)
+        raw.writeHead(200)
 
-      let streams = localStreams.get(session.id)
-      if (!streams) {
-        streams = new Set()
-        localStreams.set(session.id, streams)
-      }
-      streams.add(reply)
-
-      app.log.info({
-        sessionId: session.id,
-        totalStreams: streams.size,
-        method: 'GET'
-      }, 'Added new stream to session')
-
-      // Handle resumability with Last-Event-ID
-      const lastEventId = request.headers['last-event-id'] as string
-      if (lastEventId) {
-        app.log.info(`Resuming SSE stream from event ID: ${lastEventId}`)
-        await replayMessagesFromEventId(session.id, lastEventId, reply)
-      }
-
-      // Handle connection close
-      reply.raw.on('close', () => {
-        const streams = localStreams.get(session.id)
-        if (streams) {
-          streams.delete(reply)
-          app.log.info({
-            sessionId: session.id,
-            remainingStreams: streams.size
-          }, 'SSE connection closed')
-
-          if (streams.size === 0) {
-            app.log.info({
-              sessionId: session.id
-            }, 'Last SSE stream closed, cleaning up session')
-            localStreams.delete(session.id)
-            messageBroker.unsubscribe(`mcp/session/${session.id}/message`)
-          }
+        let streams = localStreams.get(session.id)
+        if (!streams) {
+          streams = new Set()
+          localStreams.set(session.id, streams)
         }
-      })
+        streams.add(reply)
 
-      // SEP-1699: servers may end an SSE stream whenever they like, turning the
-      // stream into a polling channel. The client reconnects with Last-Event-ID
-      // on GET and we replay whatever it missed, so closing here loses nothing.
-      let maxDurationTimer: NodeJS.Timeout | undefined
-      if (opts.sseMaxConnectionMs) {
-        maxDurationTimer = setTimeout(() => {
-          app.log.info({
-            sessionId: session.id,
-            afterMs: opts.sseMaxConnectionMs
-          }, 'Closing SSE stream to let the client poll; it may resume with Last-Event-ID')
-          try {
-            reply.raw.end()
-          } catch {
-            // already gone
-          }
-        }, opts.sseMaxConnectionMs)
-        maxDurationTimer.unref()
+        app.log.info({
+          sessionId: session.id,
+          totalStreams: streams.size,
+          method: 'GET'
+        }, 'Added new stream to session')
 
-        reply.raw.on('close', () => clearTimeout(maxDurationTimer))
-      }
+        // Handle resumability with Last-Event-ID
+        const lastEventId = request.headers['last-event-id'] as string
+        if (lastEventId) {
+          app.log.info(`Resuming SSE stream from event ID: ${lastEventId}`)
+          await replayMessagesFromEventId(session.id, lastEventId, reply)
+        }
 
-      // Send initial heartbeat
-      reply.raw.write(': heartbeat\n\n')
-
-      // Keep connection alive with periodic heartbeats
-      const heartbeatInterval = setInterval(() => {
-        try {
-          reply.raw.write(': heartbeat\n\n')
-        } catch (error) {
-          clearInterval(heartbeatInterval)
+        // Handle connection close
+        reply.raw.on('close', () => {
           const streams = localStreams.get(session.id)
           if (streams) {
             streams.delete(reply)
-          }
-        }
-      }, 30000) // 30 second heartbeat
-      heartbeatInterval.unref()
+            app.log.info({
+              sessionId: session.id,
+              remainingStreams: streams.size
+            }, 'SSE connection closed')
 
-      reply.raw.on('close', () => {
-        app.log.info({
-          sessionId: session.id
-        }, 'SSE heartbeat connection closed')
-        clearInterval(heartbeatInterval)
-      })
-    } catch (error) {
-      app.log.error({ err: error }, 'Error setting up SSE stream')
-      reply.type('application/json').code(500).send({ error: 'Internal server error' })
-    }
-  })
+            if (streams.size === 0) {
+              app.log.info({
+                sessionId: session.id
+              }, 'Last SSE stream closed, cleaning up session')
+              localStreams.delete(session.id)
+              messageBroker.unsubscribe(`mcp/session/${session.id}/message`)
+            }
+          }
+        })
+
+        // SEP-1699: servers may end an SSE stream whenever they like, turning the
+        // stream into a polling channel. The client reconnects with Last-Event-ID
+        // on GET and we replay whatever it missed, so closing here loses nothing.
+        let maxDurationTimer: NodeJS.Timeout | undefined
+        if (opts.sseMaxConnectionMs) {
+          maxDurationTimer = setTimeout(() => {
+            app.log.info({
+              sessionId: session.id,
+              afterMs: opts.sseMaxConnectionMs
+            }, 'Closing SSE stream to let the client poll; it may resume with Last-Event-ID')
+            try {
+              reply.raw.end()
+            } catch {
+            // already gone
+            }
+          }, opts.sseMaxConnectionMs)
+          maxDurationTimer.unref()
+
+          reply.raw.on('close', () => clearTimeout(maxDurationTimer))
+        }
+
+        // Send initial heartbeat
+        reply.raw.write(': heartbeat\n\n')
+
+        // Keep connection alive with periodic heartbeats
+        const heartbeatInterval = setInterval(() => {
+          try {
+            reply.raw.write(': heartbeat\n\n')
+          } catch (error) {
+            clearInterval(heartbeatInterval)
+            const streams = localStreams.get(session.id)
+            if (streams) {
+              streams.delete(reply)
+            }
+          }
+        }, 30000) // 30 second heartbeat
+        heartbeatInterval.unref()
+
+        reply.raw.on('close', () => {
+          app.log.info({
+            sessionId: session.id
+          }, 'SSE heartbeat connection closed')
+          clearInterval(heartbeatInterval)
+        })
+      } catch (error) {
+        app.log.error({ err: error }, 'Error setting up SSE stream')
+        reply.type('application/json').code(500).send({ error: 'Internal server error' })
+      }
+    })
+  }
 
   // DELETE endpoint for explicit session termination (MCP spec)
   if (enableSSE) {
-    app.delete('/mcp', { onRequest: mcpOnRequest, preHandler: mcpPreHandler }, async (request: FastifyRequest, reply: FastifyReply) => {
+    const schema = resolveMcpRouteSchema(undefined, {
+      routeId: 'mcp.delete',
+      method: 'DELETE',
+      url: mcpUrl
+    }, opts.transformRouteSchema)
+    const routeOptions = schema === undefined
+      ? { onRequest: mcpOnRequest, preHandler: mcpPreHandler }
+      : { onRequest: mcpOnRequest, preHandler: mcpPreHandler, schema }
+
+    app.delete('/mcp', routeOptions, async (request: FastifyRequest, reply: FastifyReply) => {
       const sessionId = request.headers['mcp-session-id'] as string
       if (!sessionId) {
         reply.code(400).send({ error: 'Missing Mcp-Session-Id header' })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { FastifyReply, FastifyRequest } from 'fastify'
+import type { FastifyReply, FastifyRequest, FastifySchema, HTTPMethods } from 'fastify'
 import type { Options } from 'ajv'
 import type {
   JSONRPCMessage,
@@ -180,6 +180,22 @@ export interface ToolAccessContext {
   sessionId?: string
 }
 
+export type MCPRouteId =
+  | 'mcp.post'
+  | 'mcp.get'
+  | 'mcp.delete'
+
+export interface MCPRouteSchemaContext {
+  routeId: MCPRouteId
+  method: HTTPMethods
+  url: string
+}
+
+export type MCPRouteSchemaTransformer = (
+  schema: FastifySchema,
+  context: MCPRouteSchemaContext
+) => FastifySchema
+
 export interface MCPPluginOptions {
   serverInfo?: Implementation
   capabilities?: ServerCapabilities
@@ -227,6 +243,11 @@ export interface MCPPluginOptions {
     toolName: string,
     context: ToolAccessContext
   ) => boolean | Promise<boolean>
+  /**
+   * Customize Fastify/OpenAPI schema metadata for MCP transport routes.
+   * This callback runs once per registered route during startup.
+   */
+  transformRouteSchema?: MCPRouteSchemaTransformer
   /**
    * Validate plain JSON Schema tool inputs using AJV.
    * Omit this option to disable validation, or provide an object to enable it.

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -5,7 +5,7 @@ import {
   expectNotAssignable,
 } from 'tsd'
 import { Type } from '@sinclair/typebox'
-import type { FastifyReply, FastifyRequest } from 'fastify'
+import type { FastifyReply, FastifyRequest, FastifySchema, HTTPMethods } from 'fastify'
 import { RedisMessageBroker, MemoryMessageBroker, RedisSessionStore, MemorySessionStore } from '../dist/index.js'
 import type {
   ToolHandler,
@@ -27,6 +27,9 @@ import type {
   SessionStore,
   SessionMetadata,
   ToolAccessContext,
+  MCPRouteId,
+  MCPRouteSchemaContext,
+  MCPRouteSchemaTransformer,
 } from '../dist/index.js'
 
 // ─── ToolHandler ─────────────────────────────────────────────────────
@@ -209,6 +212,45 @@ expectAssignable<UnsafeMCPPrompt>({ definition: { name: 'anything' } })
 
 // Empty options are valid
 expectAssignable<MCPPluginOptions>({})
+
+const routeSchemaContext: MCPRouteSchemaContext = {
+  routeId: 'mcp.post',
+  method: 'POST',
+  url: '/mcp'
+}
+expectType<MCPRouteId>(routeSchemaContext.routeId)
+expectType<HTTPMethods>(routeSchemaContext.method)
+
+const routeSchemaTransformer: MCPRouteSchemaTransformer = (schema, context) => {
+  const routeId: MCPRouteId = context.routeId
+  expectType<MCPRouteSchemaContext>(context)
+
+  return {
+    ...schema,
+    tags: [routeId]
+  }
+}
+
+expectAssignable<MCPPluginOptions>({
+  transformRouteSchema: routeSchemaTransformer
+})
+
+expectError<MCPRouteSchemaContext>({
+  routeId: 'invalid.route',
+  method: 'POST',
+  url: '/mcp'
+})
+
+expectNotAssignable<MCPRouteSchemaTransformer>(async (schema: FastifySchema) => {
+  return {
+    ...schema,
+    tags: ['async-not-allowed']
+  }
+})
+
+expectNotAssignable<MCPRouteSchemaTransformer>((_schema: FastifySchema) => {
+  return undefined
+})
 
 // Full options
 expectAssignable<MCPPluginOptions>({

--- a/test/route-schema-customization.test.ts
+++ b/test/route-schema-customization.test.ts
@@ -1,0 +1,333 @@
+import { describe, test } from 'node:test'
+import type { TestContext } from 'node:test'
+import Fastify from 'fastify'
+import mcpPlugin from '../src/index.ts'
+import { JSONRPC_VERSION } from '../src/schema.ts'
+import type { FastifySchema, HTTPMethods, RouteOptions } from 'fastify'
+import type { MCPRouteSchemaContext, MCPRouteSchemaTransformer } from '../src/types.ts'
+import { createTestAuthConfig } from './auth-test-utils.ts'
+
+type OpenApiRouteSchema = FastifySchema & Record<string, unknown>
+
+interface CapturedRoute {
+  method: HTTPMethods
+  url: string
+  schema: OpenApiRouteSchema | undefined
+}
+
+function captureMcpRoutes (app: ReturnType<typeof Fastify>): CapturedRoute[] {
+  const routes: CapturedRoute[] = []
+
+  app.addHook('onRoute', (route: RouteOptions) => {
+    const methods = Array.isArray(route.method) ? route.method : [route.method]
+    for (const method of methods) {
+      if (/\/mcp$/.test(route.url)) {
+        routes.push({
+          method: method as HTTPMethods,
+          url: route.url,
+          schema: route.schema as OpenApiRouteSchema | undefined
+        })
+      }
+    }
+  })
+
+  return routes
+}
+
+describe('MCP route schema customization', () => {
+  test('plugin registration works without transformRouteSchema and keeps schemas unchanged', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    const captured = captureMcpRoutes(app)
+
+    await app.register(mcpPlugin)
+    await app.ready()
+
+    const postRoute = captured.find(r => r.method === 'POST' && r.url === '/mcp')
+    const getRoute = captured.find(r => r.method === 'GET' && r.url === '/mcp')
+
+    t.assert.ok(postRoute)
+    t.assert.ok(getRoute)
+    t.assert.strictEqual(postRoute?.schema, undefined)
+    t.assert.strictEqual(getRoute?.schema, undefined)
+  })
+
+  test('transformer is called for POST only when SSE is disabled', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    const contexts: MCPRouteSchemaContext[] = []
+    const transformer: MCPRouteSchemaTransformer = (schema, context) => {
+      contexts.push(context)
+      return {
+        ...schema,
+        tags: ['MCP']
+      }
+    }
+
+    await app.register(mcpPlugin, {
+      transformRouteSchema: transformer
+    })
+    await app.ready()
+
+    t.assert.strictEqual(contexts.length, 1)
+    t.assert.strictEqual(contexts[0].routeId, 'mcp.post')
+    t.assert.strictEqual(contexts[0].method, 'POST')
+    t.assert.strictEqual(contexts[0].url, '/mcp')
+  })
+
+  test('transformer is called for POST, GET and DELETE when SSE is enabled', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    const seen = new Map<string, MCPRouteSchemaContext>()
+    const transformer: MCPRouteSchemaTransformer = (schema, context) => {
+      seen.set(context.routeId, context)
+      return {
+        ...schema,
+        operationId: context.routeId.replace('.', '-')
+      }
+    }
+
+    await app.register(mcpPlugin, {
+      enableSSE: true,
+      transformRouteSchema: transformer
+    })
+    await app.ready()
+
+    t.assert.strictEqual(seen.size, 3)
+    t.assert.strictEqual(seen.get('mcp.post')?.method, 'POST')
+    t.assert.strictEqual(seen.get('mcp.get')?.method, 'GET')
+    t.assert.strictEqual(seen.get('mcp.delete')?.method, 'DELETE')
+    t.assert.strictEqual(seen.get('mcp.post')?.url, '/mcp')
+    t.assert.strictEqual(seen.get('mcp.get')?.url, '/mcp')
+    t.assert.strictEqual(seen.get('mcp.delete')?.url, '/mcp')
+  })
+
+  test('transformer receives prefixed URL in context', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    const contexts: MCPRouteSchemaContext[] = []
+
+    await app.register(async function (instance) {
+      await instance.register(mcpPlugin, {
+        transformRouteSchema: (schema, context) => {
+          contexts.push(context)
+          return schema
+        }
+      })
+    }, { prefix: '/v1' })
+
+    await app.ready()
+
+    t.assert.strictEqual(contexts.length, 1)
+    t.assert.strictEqual(contexts[0].url, '/v1/mcp')
+  })
+
+  test('returned schema is used for route registration and can include OpenAPI metadata', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    const captured = captureMcpRoutes(app)
+
+    await app.register(mcpPlugin, {
+      enableSSE: true,
+      transformRouteSchema (schema, { routeId }) {
+        return {
+          ...schema,
+          tags: ['MCP'],
+          security: [{ oauth2: ['tools:read'] }],
+          operationId: routeId.replace('.', '-'),
+          description: `Route ${routeId}`,
+          'x-roles': ['admin']
+        }
+      }
+    })
+    await app.ready()
+
+    const postRoute = captured.find(r => r.method === 'POST' && r.url === '/mcp')
+    const getRoute = captured.find(r => r.method === 'GET' && r.url === '/mcp')
+    const deleteRoute = captured.find(r => r.method === 'DELETE' && r.url === '/mcp')
+
+    t.assert.deepStrictEqual(postRoute?.schema?.tags, ['MCP'])
+    t.assert.deepStrictEqual(postRoute?.schema?.security, [{ oauth2: ['tools:read'] }])
+    t.assert.deepStrictEqual(postRoute?.schema?.['x-roles'], ['admin'])
+
+    t.assert.strictEqual(getRoute?.schema?.operationId, 'mcp-get')
+    t.assert.strictEqual(deleteRoute?.schema?.description, 'Route mcp.delete')
+  })
+
+  test('transformer can override fields deliberately', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    const captured = captureMcpRoutes(app)
+
+    await app.register(mcpPlugin, {
+      transformRouteSchema: (schema) => ({
+        ...schema,
+        tags: ['overridden'],
+        description: 'overridden'
+      })
+    })
+
+    await app.ready()
+
+    const postRoute = captured.find(r => r.method === 'POST' && r.url === '/mcp')
+    t.assert.deepStrictEqual(postRoute?.schema?.tags, ['overridden'])
+    t.assert.strictEqual(postRoute?.schema?.description, 'overridden')
+  })
+
+  test('transformer runs only during registration and not per request', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    let calls = 0
+    await app.register(mcpPlugin, {
+      transformRouteSchema: (schema) => {
+        calls++
+        return {
+          ...schema,
+          tags: ['MCP']
+        }
+      }
+    })
+    await app.ready()
+
+    t.assert.strictEqual(calls, 1)
+
+    const request = {
+      jsonrpc: JSONRPC_VERSION,
+      id: 1,
+      method: 'ping'
+    }
+
+    const first = await app.inject({ method: 'POST', url: '/mcp', payload: request })
+    const second = await app.inject({ method: 'POST', url: '/mcp', payload: request })
+
+    t.assert.strictEqual(first.statusCode, 200)
+    t.assert.strictEqual(second.statusCode, 200)
+    t.assert.strictEqual(calls, 1)
+  })
+
+  test('thrown transformer error rejects plugin registration', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    await t.assert.rejects(async () => {
+      await app.register(mcpPlugin, {
+        transformRouteSchema: () => {
+          throw new Error('schema transform failed')
+        }
+      })
+      await app.ready()
+    }, /schema transform failed/)
+  })
+
+  test('invalid transformer return values reject plugin registration with route id', async (t: TestContext) => {
+    const invalidCases = [
+      { value: undefined, expected: /mcp\.post/ },
+      { value: null, expected: /mcp\.post/ },
+      { value: [], expected: /mcp\.post/ },
+      { value: 42, expected: /mcp\.post/ },
+      { value: 'invalid', expected: /mcp\.post/ }
+    ]
+
+    for (const testCase of invalidCases) {
+      const app = Fastify()
+      t.after(() => app.close())
+
+      await t.assert.rejects(async () => {
+        await app.register(mcpPlugin, {
+          transformRouteSchema: () => testCase.value as any
+        })
+        await app.ready()
+      }, testCase.expected)
+    }
+  })
+
+  test('async transformers are rejected at runtime', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    const asyncTransformer = async (schema: FastifySchema) => ({
+      ...schema,
+      tags: ['MCP']
+    })
+
+    await t.assert.rejects(async () => {
+      await app.register(mcpPlugin, {
+        // Deliberately bypass TypeScript to mimic JavaScript consumers and casts.
+        transformRouteSchema: asyncTransformer as unknown as MCPRouteSchemaTransformer
+      })
+      await app.ready()
+    }, /must return a synchronous Fastify schema object for mcp\.post/)
+  })
+
+  test('two encapsulated plugin instances use independent transformers', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    const captured = captureMcpRoutes(app)
+
+    await app.register(async function (instance) {
+      await instance.register(mcpPlugin, {
+        transformRouteSchema (schema) {
+          return {
+            ...schema,
+            tags: ['instance-a']
+          }
+        }
+      })
+    }, { prefix: '/a' })
+
+    await app.register(async function (instance) {
+      await instance.register(mcpPlugin, {
+        transformRouteSchema (schema) {
+          return {
+            ...schema,
+            tags: ['instance-b']
+          }
+        }
+      })
+    }, { prefix: '/b' })
+
+    await app.ready()
+
+    const aPost = captured.find(r => r.method === 'POST' && r.url === '/a/mcp')
+    const bPost = captured.find(r => r.method === 'POST' && r.url === '/b/mcp')
+
+    t.assert.deepStrictEqual(aPost?.schema?.tags, ['instance-a'])
+    t.assert.deepStrictEqual(bPost?.schema?.tags, ['instance-b'])
+  })
+
+  test('transformer does not run for unrelated or OAuth routes', async (t: TestContext) => {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    const contexts: MCPRouteSchemaContext[] = []
+
+    app.get('/health', {
+      schema: {
+        description: 'health route'
+      } as FastifySchema
+    }, async () => ({ ok: true }))
+
+    await app.register(mcpPlugin, {
+      authorization: createTestAuthConfig(),
+      transformRouteSchema: (schema, context) => {
+        contexts.push(context)
+        return {
+          ...schema,
+          tags: ['MCP']
+        }
+      }
+    })
+    await app.ready()
+
+    t.assert.strictEqual(contexts.length, 1)
+    t.assert.strictEqual(contexts[0].routeId, 'mcp.post')
+  })
+})


### PR DESCRIPTION
add `transformRouteSchema` to allow customizing Fastify/OpenAPI schema metadata on MCP transport routes without replacing handlers or route definitions