### PR TITLE
feat(auth): expose tool access operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1539,19 +1539,22 @@ Tool-level checks like the one above keep the tool visible to every client and o
 ```typescript
 await app.register(mcpPlugin, {
   authorization: { /* ... */ },
-  canAccessTool: (toolName, { authContext }) => {
-    if (toolName === 'admin-tool') {
-      return authContext?.scopes?.includes('tools:admin') === true
+  canAccessTool: (toolName, context) => {
+    if (context.operation === 'list') {
+      return canSeeTool(toolName, context.authContext)
     }
-    return true
+
+    return canExecuteTool(toolName, context.authContext)
   }
 })
 ```
 
-The hook receives the tool name and a per-request context (`authContext`, `request`, `sessionId`), and may be sync or async. It is consulted at both dispatch points, so list and call can never disagree:
+The hook receives the tool name and a per-request context (`authContext`, `request`, `sessionId`, `operation`), and may be sync or async. It is consulted at both dispatch points, so list and call can never disagree:
 
-- `tools/list` omits every tool the hook denies for that request. Per-tool checks run concurrently with a fixed cap (8 at a time), so an async hook backed by a database or HTTP service is not flooded with one lookup per registered tool; the listing keeps registration order.
-- `tools/call` on a denied tool returns the same `-32601` "Tool 'name' not found" protocol error as an unknown tool, and the hook runs even for unknown names, so callers cannot probe for tools they are not allowed to see by response shape. Response timing is not guaranteed to be indistinguishable — it depends on what the hook itself does per name. Task-augmented calls (`task` field) go through the same gate.
+- `tools/list` omits every tool the hook denies for that request, calling the hook with `operation: 'list'`. Per-tool checks run concurrently with a fixed cap (8 at a time), so an async hook backed by a database or HTTP service is not flooded with one lookup per registered tool; the listing keeps registration order.
+- `tools/call` on a denied tool returns the same `-32601` "Tool 'name' not found" protocol error as an unknown tool, calling the hook with `operation: 'call'`. The hook runs even for unknown names, so callers cannot probe for tools they are not allowed to see by response shape. Response timing is not guaranteed to be indistinguishable — it depends on what the hook itself does per name. Task-augmented calls (`task` field) and `app.mcpCallTool()` also use `operation: 'call'`.
+
+Visibility and execution policies may intentionally differ — a tool hidden from `tools/list` can still be callable by a client that already knows its name.
 
 A hook that throws denies access (fail closed) and logs a warning. Only an explicit `true` grants access. Without the hook, every registered tool stays visible and callable.
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -31,7 +31,7 @@ import {
 } from './schema.ts'
 import type { RequestId } from './schema.ts'
 
-import type { MCPTool, MCPResource, MCPPrompt, MCPPluginOptions, ResourceHandlers, McpCallToolOutcome } from './types.ts'
+import type { MCPTool, MCPResource, MCPPrompt, MCPPluginOptions, ResourceHandlers, McpCallToolOutcome, ToolAccessOperation } from './types.ts'
 import type { SessionStore } from './stores/session-store.ts'
 import type { TaskStore, TaskRecord, TaskWaiters } from './stores/task-store.ts'
 import { isTerminal, toWireTask } from './stores/task-store.ts'
@@ -173,19 +173,25 @@ function withSchemaDialect<T> (schema: T, protocolVersion: string | undefined): 
  * exposing a tool the deployment meant to gate; the error is logged so a
  * misbehaving hook is visible to the operator.
  */
-async function checkToolAccess (toolName: string, dependencies: ToolCallDependencies): Promise<boolean> {
+async function checkToolAccess (
+  toolName: string,
+  operation: ToolAccessOperation,
+  dependencies: ToolCallDependencies
+): Promise<boolean> {
   const hook = dependencies.opts.canAccessTool
   if (!hook) return true
   try {
     return await hook(toolName, {
       authContext: dependencies.authContext,
       request: dependencies.request,
-      sessionId: dependencies.sessionId
+      sessionId: dependencies.sessionId,
+      operation
     }) === true
   } catch (error) {
     dependencies.request.log.warn({
       err: error,
-      tool: toolName
+      tool: toolName,
+      operation
     }, 'canAccessTool hook threw; denying access')
     return false
   }
@@ -218,7 +224,7 @@ async function handleToolsList (request: JSONRPCRequest, dependencies: HandlerDe
   const accessResults = await mapWithConcurrency(
     registeredTools,
     TOOL_ACCESS_CONCURRENCY,
-    tool => checkToolAccess(tool.definition.name, dependencies)
+    tool => checkToolAccess(tool.definition.name, 'list', dependencies)
   )
   const accessibleTools = registeredTools.filter((_tool, index) => accessResults[index])
   const result: ListToolsResult = {
@@ -334,7 +340,7 @@ async function resolveRegisteredTool (
   toolName: string,
   dependencies: ToolCallDependencies
 ): Promise<{ ok: true, tool: MCPTool } | { ok: false, reason: 'not-found' }> {
-  const isAllowed = await checkToolAccess(toolName, dependencies)
+  const isAllowed = await checkToolAccess(toolName, 'call', dependencies)
   if (!isAllowed) {
     return { ok: false, reason: 'not-found' }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,6 +277,7 @@ export type {
   MCPRouteSchemaContext,
   MCPRouteSchemaTransformer,
   ToolAccessContext,
+  ToolAccessOperation,
   McpCallToolContext,
   McpCallToolOutcome,
   MCPTool,

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,11 +181,19 @@ export interface UnsafeMCPPrompt {
   handler?: UnsafePromptHandler
 }
 
+/**
+ * Which operation `canAccessTool` is deciding: `list` for `tools/list`
+ * visibility, `call` for `tools/call` execution (including HTTP,
+ * task-augmented, and `mcpCallTool()` calls, and calls to unknown tools).
+ */
+export type ToolAccessOperation = 'list' | 'call'
+
 /** Per-request context handed to the `canAccessTool` hook. */
 export interface ToolAccessContext {
   authContext?: AuthorizationContext
   request: FastifyRequest
   sessionId?: string
+  operation: ToolAccessOperation
 }
 
 export type MCPRouteId =
@@ -257,6 +265,10 @@ export interface MCPPluginOptions {
    * `tools/call` runs the hook even for unknown names. Response timing is not
    * guaranteed to be indistinguishable: it depends on what the hook itself
    * does per name. A hook that throws denies access.
+   * `context.operation` tells the hook which decision it is making: `'list'`
+   * for `tools/list` visibility, `'call'` for execution (HTTP, task-augmented,
+   * and `mcpCallTool()` calls, and unknown tool names, all use `'call'`).
+   * Visibility and execution policies may intentionally differ.
    * Omit to keep every registered tool visible and callable.
    */
   canAccessTool?: (

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -359,12 +359,16 @@ const accessHook: NonNullable<MCPPluginOptions['canAccessTool']> = (toolName, co
   expectType<string>(toolName)
   expectAssignable<string[] | undefined>(context.authContext?.scopes)
   expectAssignable<string | undefined>(context.sessionId)
+  expectType<'list' | 'call'>(context.operation)
   return context.request !== undefined
 }
 expectAssignable<MCPPluginOptions>({ canAccessTool: accessHook })
 
-// The context type is exported and carries a required request
-expectAssignable<ToolAccessContext>({ request: {} as FastifyRequest })
+// The context type is exported and carries a required request and operation
+expectAssignable<ToolAccessContext>({ request: {} as FastifyRequest, operation: 'list' })
+expectAssignable<ToolAccessContext>({ request: {} as FastifyRequest, operation: 'call' })
+expectNotAssignable<ToolAccessContext>({ request: {} as FastifyRequest })
+expectNotAssignable<ToolAccessContext>({ request: {} as FastifyRequest, operation: 'delete' })
 expectNotAssignable<ToolAccessContext>({})
 
 // mcpCallTool is decorated on Fastify and returns the exported outcome union

--- a/test/mcp-call-tool.test.ts
+++ b/test/mcp-call-tool.test.ts
@@ -29,6 +29,7 @@ async function buildApp (t: TestContext) {
   let taskOnlyInvocations = 0
   let jsonSchemaInvocations = 0
   let accessContextRequest: FastifyRequest | undefined
+  let accessContextOperation: string | undefined
   let directRouteRequest: FastifyRequest | undefined
 
   const app = Fastify({ logger: false })
@@ -39,6 +40,7 @@ async function buildApp (t: TestContext) {
     validateJsonSchemaInputs: {},
     canAccessTool: (toolName, context) => {
       accessContextRequest = context.request
+      accessContextOperation = context.operation
       if (toolName === 'wallet-summary') {
         return context.authContext?.scopes?.includes('wallet-summary:read') === true
       }
@@ -177,6 +179,7 @@ async function buildApp (t: TestContext) {
     getJsonSchemaInvocations: () => jsonSchemaInvocations,
     getTaskOnlyInvocations: () => taskOnlyInvocations,
     getAccessContextRequest: () => accessContextRequest,
+    getAccessContextOperation: () => accessContextOperation,
     getDirectRouteRequest: () => directRouteRequest
   }
 }
@@ -277,6 +280,18 @@ describe('mcpCallTool', () => {
     })
 
     t.assert.strictEqual(getAccessContextRequest(), getDirectRouteRequest())
+  })
+
+  test('mcpCallTool() invokes canAccessTool with operation call', async (t: TestContext) => {
+    const { app, getAccessContextOperation } = await buildApp(t)
+
+    await app.inject({
+      method: 'POST',
+      url: '/direct-tool-call',
+      payload: { name: 'echo', args: { message: 'hello' } }
+    })
+
+    t.assert.strictEqual(getAccessContextOperation(), 'call')
   })
 
   test('matches the JSON-RPC tools/call path for success and failure outcomes', async (t: TestContext) => {

--- a/test/tool-authorization.test.ts
+++ b/test/tool-authorization.test.ts
@@ -107,12 +107,12 @@ describe('Tool Authorization (canAccessTool)', () => {
     t.assert.strictEqual(unknownBody.error.message, "Tool 'no-such-tool' not found")
   })
 
-  test('the hook is invoked for unknown tool names too', async (t: TestContext) => {
+  test('the hook is invoked for unknown tool names too, with operation call', async (t: TestContext) => {
     // Same code path for unknown and denied names: identical protocol response
-    const checkedNames: string[] = []
+    const checked: Array<{ toolName: string, operation: string }> = []
     const app = await buildApp(t, {
-      canAccessTool: async (toolName) => {
-        checkedNames.push(toolName)
+      canAccessTool: async (toolName, context) => {
+        checked.push({ toolName, operation: context.operation })
         await new Promise(resolve => setImmediate(resolve))
         return toolName !== 'restricted-tool'
       }
@@ -121,17 +121,38 @@ describe('Tool Authorization (canAccessTool)', () => {
     await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('restricted-tool') })
     await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('no-such-tool') })
 
+    const checkedNames = checked.map(c => c.toolName)
     t.assert.ok(checkedNames.includes('restricted-tool'), 'denied registered name must be checked')
     t.assert.ok(checkedNames.includes('no-such-tool'), 'unknown name must be checked')
+    t.assert.ok(checked.every(c => c.operation === 'call'), 'tools/call always supplies operation call')
   })
 
-  test('tools/list evaluates independent checks concurrently', async (t: TestContext) => {
+  test('tools/list supplies operation list, tools/call supplies operation call', async (t: TestContext) => {
+    const operations: string[] = []
+    const app = await buildApp(t, {
+      canAccessTool: (_toolName, context) => {
+        operations.push(context.operation)
+        return true
+      }
+    })
+
+    await app.inject({ method: 'POST', url: '/mcp', payload: listRequest() })
+    t.assert.ok(operations.length > 0 && operations.every(op => op === 'list'))
+
+    operations.length = 0
+    await app.inject({ method: 'POST', url: '/mcp', payload: callRequest('public-tool') })
+    t.assert.deepStrictEqual(operations, ['call'])
+  })
+
+  test('tools/list evaluates independent checks concurrently, all with operation list', async (t: TestContext) => {
     let activeChecks = 0
     let maxConcurrentChecks = 0
+    const operations: string[] = []
     const app = await buildApp(t, {
-      canAccessTool: async () => {
+      canAccessTool: async (_toolName, context) => {
         activeChecks++
         maxConcurrentChecks = Math.max(maxConcurrentChecks, activeChecks)
+        operations.push(context.operation)
         await new Promise(resolve => setImmediate(resolve))
         activeChecks--
         return true
@@ -143,6 +164,7 @@ describe('Tool Authorization (canAccessTool)', () => {
     t.assert.strictEqual(maxConcurrentChecks, 2)
     // Concurrency must not reorder: registration order is preserved
     t.assert.deepStrictEqual(listedToolNames(listResponse), ['public-tool', 'restricted-tool'])
+    t.assert.deepStrictEqual(operations, ['list', 'list'])
   })
 
   test('tools/list caps concurrent hook evaluations with many tools', async (t: TestContext) => {
@@ -230,12 +252,16 @@ describe('Tool Authorization (canAccessTool)', () => {
     t.assert.deepStrictEqual(listedToolNames(listResponse), [])
   })
 
-  test('task-augmented calls inherit the gate', async (t: TestContext) => {
+  test('task-augmented calls inherit the gate, with operation call', async (t: TestContext) => {
+    const operations: string[] = []
     const app = Fastify({ logger: false })
     t.after(() => app.close())
     await app.register(mcpPlugin, {
       enableTasks: true,
-      canAccessTool: (toolName) => toolName !== 'restricted-task-tool'
+      canAccessTool: (toolName, context) => {
+        operations.push(context.operation)
+        return toolName !== 'restricted-task-tool'
+      }
     })
     app.mcpAddTool({
       name: 'restricted-task-tool',
@@ -259,6 +285,7 @@ describe('Tool Authorization (canAccessTool)', () => {
     const taskCallBody = taskCallResponse.json() as JSONRPCErrorResponse
     t.assert.strictEqual(taskCallBody.error.code, METHOD_NOT_FOUND)
     t.assert.strictEqual(taskCallBody.error.message, "Tool 'restricted-task-tool' not found")
+    t.assert.deepStrictEqual(operations, ['call'])
   })
 
   test('hook receives the authContext of the calling token', async (t: TestContext) => {


### PR DESCRIPTION
Add an operation field to ToolAccessContext so canAccessTool hooks know whether they're gating tools/list or tools/call without inspecting the raw request.